### PR TITLE
[Issue #22]- Fixes an anomaly on a request without Internet connection

### DIFF
--- a/Sources/SmartyStreets/HTTPSender.swift
+++ b/Sources/SmartyStreets/HTTPSender.swift
@@ -49,7 +49,7 @@ class HttpSender: SmartySender {
         } catch let buildError {
             error = buildError as NSError
         }
-        if error != nil {
+        if error != nil && response != nil {
             response.statusCode = 200
         }
         return response


### PR DESCRIPTION
Fixes the issue - https://github.com/smartystreets/smartystreets-ios-sdk/issues/22

### Work description:
Added a nil check `if response != nil` to avoid an anomaly at the time when we send a request (`override func sendRequest(request: SmartyRequest, error: inout NSError!)`) and there is no Internet connection.


### Other:
smartystreets-ios-sdk version: 8.7.1
Xcode version: 12.5 (12E262)
Swift version: 5.4
Platform running smartystreets-ios-sdk: iPhone 12 Simulator, iOS 14.5 (18E182)
macOS version running Xcode: Big Sur 11.2.3