### PR TITLE
Fix: copy all candidates to all lookups

### DIFF
--- a/Sources/SmartyStreets/USStreet/USStreetClient.swift
+++ b/Sources/SmartyStreets/USStreet/USStreetClient.swift
@@ -92,10 +92,12 @@ public class USStreetClient: NSObject {
     func assignCandidatesToLookups(lookups: [USStreetLookup], candidates:[USStreetCandidate]) {
         for i in 0..<candidates.count {
             let candidate = candidates[i]
-            if lookups[i].result == nil {
-                lookups[i].result = [candidate]
-            } else {
-                lookups[i].result.append(candidate)
+            for j in 0..<lookups.count {
+                if lookups[j].result == nil {
+                    lookups[j].result = [candidate]
+                } else {
+                    lookups[j].result.append(candidate)
+                }
             }
         }
     }


### PR DESCRIPTION
Was crashing with less lookups than candidates
- Also copied only one candidate per lookup

Please read:

This copies ALL candidates to ALL lookups. I am not sure if each lookup can or should have different candidates, but this code will result in all lookups having the same result candidates.

This also affects USStreet API only (only API we use). I am unsure if the issue is in any other API or non-iOS platform.