### PR TITLE
[Issue #34] Fix for array urlencoding (XCode 15.0.1, iOS 17.0)

### DIFF
--- a/Sources/SmartyStreets/SmartyRequest.swift
+++ b/Sources/SmartyStreets/SmartyRequest.swift
@@ -54,7 +54,9 @@ public class SmartyRequest {
     }
     
     func urlEncode(value: String) -> String {
-        return value.addingPercentEncoding(withAllowedCharacters: .urlPathAllowed)!
+        var allowedCharacters = CharacterSet.urlPathAllowed
+        allowedCharacters.remove(";")
+        return value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
     }
     
     func setPayload(payload:Data) {

--- a/Sources/SmartyStreets/SmartyRequest.swift
+++ b/Sources/SmartyStreets/SmartyRequest.swift
@@ -55,7 +55,7 @@ public class SmartyRequest {
     
     func urlEncode(value: String) -> String {
         var allowedCharacters = CharacterSet.urlPathAllowed
-        allowedCharacters.remove(";")
+        allowedCharacters.remove(charactersIn: USAutocompleteProClient.arrayItemsSeparator)
         return value.addingPercentEncoding(withAllowedCharacters: allowedCharacters)!
     }
     

--- a/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProClient.swift
+++ b/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProClient.swift
@@ -2,7 +2,9 @@ import Foundation
 
 public class USAutocompleteProClient: NSObject {
     //    It is recommended to instantiate this class using SSClientBuilder
-    
+
+    static let arrayItemsSeparator = ";"
+
     var sender:SmartySender
     public var serializer:SmartySerializer
     
@@ -65,6 +67,6 @@ public class USAutocompleteProClient: NSObject {
             return String()
         }
         
-        return list.joined(separator: ";")
+        return list.joined(separator: Self.arrayItemsSeparator)
     }
 }

--- a/Sources/SmartyStreets/USReverseGeo/USReverseGeoSerializer.swift
+++ b/Sources/SmartyStreets/USReverseGeo/USReverseGeoSerializer.swift
@@ -5,6 +5,7 @@ class USReverseGeoSerializer: SmartySerializer {
         let raw:USReverseGeoLookup? = obj as? USReverseGeoLookup
         let smartyErrors = SmartyErrors()
         let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .sortedKeys
         if raw == nil {
             let details = [NSLocalizedDescriptionKey: "The object to be serialized is nil"]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)

--- a/Sources/SmartyStreets/USStreet/USStreetSerializer.swift
+++ b/Sources/SmartyStreets/USStreet/USStreetSerializer.swift
@@ -6,6 +6,7 @@ public class USStreetSerializer: SmartySerializer {
         let raw:[USStreetLookup]? = obj as? [USStreetLookup]
         let smartyErrors = SmartyErrors()
         let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .sortedKeys
         if raw == nil {
             let details = [NSLocalizedDescriptionKey: "The object to be serialized is nil"]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)

--- a/Sources/SmartyStreets/USZipCode/USZipCodeSerializer.swift
+++ b/Sources/SmartyStreets/USZipCode/USZipCodeSerializer.swift
@@ -5,6 +5,7 @@ public class USZipCodeSerializer: SmartySerializer {
         let raw:[USZipCodeLookup]? = obj as? [USZipCodeLookup]
         let smartyErrors = SmartyErrors()
         let jsonEncoder = JSONEncoder()
+        jsonEncoder.outputFormatting = .sortedKeys
         if raw == nil {
             let details = [NSLocalizedDescriptionKey: "The object to be serialized is nil"]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)

--- a/Sources/SmartyStreets/Version.swift
+++ b/Sources/SmartyStreets/Version.swift
@@ -1,3 +1,3 @@
 class Version {
-    let version = "8.10.17b001"
+    let version = "8.10.17"
 }

--- a/Sources/SmartyStreets/Version.swift
+++ b/Sources/SmartyStreets/Version.swift
@@ -1,3 +1,3 @@
 class Version {
-    let version = "8.10.17"
+    let version = "8.10.17b001"
 }

--- a/Tests/SmartyStreetsTests/SerializerTests.swift
+++ b/Tests/SmartyStreetsTests/SerializerTests.swift
@@ -76,7 +76,7 @@ class SerializerTests: XCTestCase {
     
     func testSerialize() {
         let expectedOutput = """
-        [{"state":"02","inputId":"04","city":"01","zipcode":"03"},{"state":"06","inputId":"08","city":"05","zipcode":"07"}]
+        [{"city":"01","inputId":"04","state":"02","zipcode":"03"},{"city":"05","inputId":"08","state":"06","zipcode":"07"}]
         """
         let lookup1 = USZipCodeLookup(city: "01", state: "02", zipcode: "03", inputId: "04")
         let lookup2 = USZipCodeLookup(city: "05", state: "06", zipcode: "07", inputId: "08")

--- a/Tests/SmartyStreetsTests/SmartyRequestTests.swift
+++ b/Tests/SmartyStreetsTests/SmartyRequestTests.swift
@@ -44,4 +44,10 @@ class SmartyRequestTests: XCTestCase {
         XCTAssertEqual(url, "https://fakesearch.com/lookup?street=Parks%20Blvd")
     }
     
+    func testGetURLWithURLEncodedArray() {
+        smartyRequest.urlPrefix = "https://fakesearch.com/lookup?"
+        smartyRequest.setValue(value: "abc;def", HTTPParameterField: "array")
+        let url = smartyRequest.getUrl()
+        XCTAssertEqual(url, "https://fakesearch.com/lookup?array=abc%3Bdef")
+    }
 }

--- a/Tests/SmartyStreetsTests/USReverseGeoTests/USReverseGeoSerializerTests.swift
+++ b/Tests/SmartyStreetsTests/USReverseGeoTests/USReverseGeoSerializerTests.swift
@@ -42,7 +42,7 @@ class USReverseGeoSerializerTests: XCTestCase {
     
     func testSerialize() {
         let expectedOutput = """
-        {"source":"","longitude":"-111.11111111","latitude":"44.88888889"}
+        {"latitude":"44.88888889","longitude":"-111.11111111","source":""}
         """
         
         let lookup = USReverseGeoLookup(latitude: 44.888888888, longitude: -111.111111111, source: "")

--- a/Tests/SmartyStreetsTests/USStreetTests/USStreetCandidateTests.swift
+++ b/Tests/SmartyStreetsTests/USStreetTests/USStreetCandidateTests.swift
@@ -10,7 +10,7 @@ class USStreetCandidateTests: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        [{\"state\":\"state_value\",\"secondary\":\"secondary\",\"street2\":\"street2_value\",\"street\":\"street_value\",\"maxCandidates\":5,\"urbanization\":\"urbanization_value\",\"matchStrategy\":\"match_value\",\"city\":\"city_value\",\"result\":[],\"zipCode\":\"zipCode_value\",\"addressee\":\"addressee_value\",\"lastline\":\"lastline_value\"},{\"result\":[],\"maxCandidates\":1,\"state\":\"California\",\"street\":\"1600 amphitheatre parkway\",\"city\":\"Mountain view\"},{\"result\":[],\"street\":\"1 Rosedale, Baltimore, Maryland\",\"maxCandidates\":1}]
+        [{\"addressee\":\"addressee_value\",\"city\":\"city_value\",\"lastline\":\"lastline_value\",\"matchStrategy\":\"match_value\",\"maxCandidates\":5,\"result\":[],\"secondary\":\"secondary\",\"state\":\"state_value\",\"street\":\"street_value\",\"street2\":\"street2_value\",\"urbanization\":\"urbanization_value\",\"zipCode\":\"zipCode_value\"},{\"city\":\"Mountain view\",\"maxCandidates\":1,\"result\":[],\"state\":\"California\",\"street\":\"1600 amphitheatre parkway\"},{\"maxCandidates\":1,\"result\":[],\"street\":\"1 Rosedale, Baltimore, Maryland\"}]
         """
         
         obj = [


### PR DESCRIPTION
Fixes the issue - https://github.com/smartystreets/smartystreets-ios-sdk/issues/34

### Description

On the following environment:
- MacOS: Sonoma 14.1.1
- XCode 15.0.1
- iOS 17.0

.. there is an issue that `exclude_states` parameter, containing more than one state, for example ["PR', "VI"] 
was not percentage encoded and it was sending this array as raw string: `exclude_states=PPR;VI`, but it should be `exclude_states=PR%3BVI`. Without this second form request is rejected. 

When I've checked encoding part I've found that SmartyStreets uses `CharacterSet.urlPathAllowed` set.
It looks like in new iOS SDK character ";" is now in this allowed characters set.
That's why I've modified this part a bit just by removing this character from this set.

## Tests
New test for this issue has been added: `SmartyRequestsTests/testGetURLWithURLEncodedArray`

Three tests for generating url request were failing, because generated url parameters were created in random order.
I guess this was passing on previous iOS SDK, but I have not easy way to check it now.
That's I've just focus on making it work on new iOS SDK.
The solution was just telling JSONEncoder to format final string with alphabetical order of keys.
Theoretically I do not see the reason, why it would be a problem to make it work in this way, but of course if you see any, than the tests would need to be reworked to eliminate this random behaviour.


