### PR TITLE
Enrichment Address Search

### DIFF
--- a/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteClient.swift
+++ b/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteClient.swift
@@ -51,6 +51,9 @@ public class InternationalAutocompleteClient: NSObject {
         request.setValue(value: lookup.maxResults.flatMap { String($0) } ?? "10", HTTPParameterField: "max_results")
         request.setValue(value: lookup.locality ?? "", HTTPParameterField: "include_only_locality")
         request.setValue(value: lookup.postalCode ?? "", HTTPParameterField: "include_only_postal_code")
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
         
         return request
     }

--- a/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteLookup.swift
+++ b/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteLookup.swift
@@ -8,6 +8,7 @@ import Foundation
     
     static let SSMaxResults = 10
     
+    private var customParamArray: [String: String] = [:]
     public var result:InternationalAutocompleteResult?
     public var country:String?
     public var search:String?
@@ -40,6 +41,14 @@ import Foundation
         } else {
             return InternationalAutocompleteCandidate(dictionary: NSDictionary())
         }
+    }
+    
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
     
     public func setMaxResults(maxResults: Int, error: inout NSError?) {

--- a/Sources/SmartyStreets/InternationalStreet/InternationalStreetClient.swift
+++ b/Sources/SmartyStreets/InternationalStreet/InternationalStreetClient.swift
@@ -50,6 +50,10 @@ public class InternationalStreetClient: NSObject {
         request.setValue(value: lookup.administrativeArea ?? "", HTTPParameterField: "administrative_area")
         request.setValue(value: lookup.postalCode ?? "", HTTPParameterField: "postal_code")
         
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
+        
         return request
     }
     

--- a/Sources/SmartyStreets/InternationalStreet/InternationalStreetLookup.swift
+++ b/Sources/SmartyStreets/InternationalStreet/InternationalStreetLookup.swift
@@ -13,6 +13,7 @@ import Foundation
     //    When set to language_mode.Native, the results will always be in the language of the output country.
     //    When set to language_mode.Latin, the results will always be provided using a Latin character set.
     
+    private var customParamArray: [String: String] = [:]
     public var result:[InternationalStreetCandidate]?
     public var inputId:String?
     public var country:String?
@@ -98,5 +99,13 @@ import Foundation
         } else {
             self.geocode = "false"
         }
+    }
+    
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
 }

--- a/Sources/SmartyStreets/SmartyErrors.swift
+++ b/Sources/SmartyStreets/SmartyErrors.swift
@@ -11,6 +11,7 @@ class SmartyErrors {
         case NotPositiveIntergerError
         case JSONSerializationError
         case MaxRetriesExceededError
+        case NotModifiedInfo = 304
         case BadRequestError = 400
         case BadCredentialsError = 401
         case PaymentRequiredError = 402

--- a/Sources/SmartyStreets/StatusCodeSender.swift
+++ b/Sources/SmartyStreets/StatusCodeSender.swift
@@ -26,6 +26,10 @@ class StatusCodeSender: SmartySender {
         switch response?.statusCode {
         case 200:
             return response
+        case 304:
+            let details = [NSLocalizedDescriptionKey:"Not Modified. This data has not been modified since it was last retrieved."]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.NotModifiedInfo.rawValue, userInfo: details)
+            return response
         case 400:
             let details = [NSLocalizedDescriptionKey:"Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON."]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.BadRequestError.rawValue, userInfo: details)

--- a/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProClient.swift
+++ b/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProClient.swift
@@ -59,6 +59,10 @@ public class USAutocompleteProClient: NSObject {
             request.setValue(value: lookup.preferGeolocation!.name, HTTPParameterField: "prefer_geolocation")
         }
         
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
+        
         return request
     }
     

--- a/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProLookup.swift
+++ b/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProLookup.swift
@@ -19,6 +19,7 @@ import Foundation
     let SSMaxResults = 10
     let SSPreferRatio = 3
     
+    private var customParamArray: [String: String] = [:]
     public var result:USAutocompleteProResult?
     public var search:String?
     public var selected:String?
@@ -90,6 +91,10 @@ import Foundation
         }
     }
     
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
     public func setMaxResults(maxResults: Int, error: inout NSError?) {
         if maxResults > 0 && maxResults <= 10 {
             self.maxResults = maxResults
@@ -121,5 +126,9 @@ import Foundation
     
     public func addPreferZIPCode(zipcode:String) {
         self.preferZIPCodes?.append(zipcode)
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
 }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/EnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/EnrichmentLookup.swift
@@ -1,14 +1,44 @@
 import Foundation
 
 public class EnrichmentLookup: Encodable {
-    private let smarty_key: String
+    private var smarty_key: String
     private let data_set_name: String
     private let data_subset_name: String
+    private var include_array: [String]
+    private var exclude_array: [String]
+    private var street: String
+    private var city: String
+    private var state: String
+    private var zipcode: String
+    private var freeform: String
+    private var etag: String
 
     public init(smartyKey: String, datasetName: String, dataSubsetName: String) {
         self.smarty_key = smartyKey
         self.data_set_name = datasetName
         self.data_subset_name = dataSubsetName
+        self.include_array = [String]()
+        self.exclude_array = [String]()
+        self.street = ""
+        self.city = ""
+        self.state = ""
+        self.zipcode = ""
+        self.freeform = ""
+        self.etag = ""
+    }
+    
+    public init() {
+        self.smarty_key = ""
+        self.data_set_name = ""
+        self.data_subset_name = ""
+        self.include_array = [String]()
+        self.exclude_array = [String]()
+        self.street = ""
+        self.city = ""
+        self.state = ""
+        self.zipcode = ""
+        self.freeform = ""
+        self.etag = ""
     }
 
     public func getSmartyKey() -> String {
@@ -21,6 +51,74 @@ public class EnrichmentLookup: Encodable {
 
     public func getDataSubsetName() -> String {
         return data_subset_name
+    }
+    
+    public func getIncludeAttributes() -> [String] {
+        return self.include_array
+    }
+    
+    public func getExcludeAttributes() -> [String] {
+        return self.exclude_array
+    }
+    
+    public func getStreet() -> String {
+        return self.street
+    }
+    
+    public func getCity() -> String {
+        return self.city
+    }
+    
+    public func getState() -> String {
+        return self.state
+    }
+    
+    public func getZipcode() -> String {
+        return self.zipcode
+    }
+    
+    public func getFreeform() -> String {
+        return self.freeform
+    }
+    
+    public func getEtag() -> String{
+        return self.etag
+    }
+    
+    public func setSmartyKey(smarty_key: String) {
+        self.smarty_key = smarty_key
+    }
+    
+    public func addIncludeAttribute(attribute: String) {
+        self.include_array.append(attribute)
+    }
+    
+    public func addExcludeAttribute(attribute: String) {
+        self.exclude_array.append(attribute)
+    }
+    
+    public func setStreet(street: String) {
+        self.street = street
+    }
+    
+    public func setCity(city: String) {
+        self.city = city
+    }
+    
+    public func setState(state: String) {
+        self.state = state
+    }
+    
+    public func setZipcode(zipcode: String) {
+        self.zipcode = zipcode
+    }
+    
+    public func setFreeform(freeform: String) {
+        self.freeform = freeform
+    }
+    
+    public func setEtag(etag: String) {
+        self.etag = etag
     }
 
     public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/EnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/EnrichmentLookup.swift
@@ -12,6 +12,7 @@ public class EnrichmentLookup: Encodable {
     private var zipcode: String
     private var freeform: String
     private var etag: String
+    private var custom_param_array: [String: String] = [:]
 
     public init(smartyKey: String, datasetName: String, dataSubsetName: String) {
         self.smarty_key = smartyKey
@@ -85,6 +86,10 @@ public class EnrichmentLookup: Encodable {
         return self.etag
     }
     
+    public func getCustomParamArray() -> [String: String] {
+        return self.custom_param_array
+    }
+    
     public func setSmartyKey(smarty_key: String) {
         self.smarty_key = smarty_key
     }
@@ -119,6 +124,10 @@ public class EnrichmentLookup: Encodable {
     
     public func setEtag(etag: String) {
         self.etag = etag
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.custom_param_array.updateValue(value, forKey: parameter)
     }
 
     public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/GeoReferenceEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/GeoReferenceEnrichmentLookup.swift
@@ -24,6 +24,9 @@ public class GeoReferenceEnrichmentLookup: EnrichmentLookup {
         self.setZipcode(zipcode: lookup.getZipcode())
         self.setFreeform(freeform: lookup.getFreeform())
         self.setEtag(etag: lookup.getEtag())
+        for key in lookup.getCustomParamArray().keys {
+            self.addCustomParameter(parameter: key, value: lookup.getCustomParamArray()[key] ?? "")
+        }
     }
     
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/GeoReferenceEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/GeoReferenceEnrichmentLookup.swift
@@ -9,6 +9,23 @@ public class GeoReferenceEnrichmentLookup: EnrichmentLookup {
         super.init(smartyKey: smartyKey, datasetName: "geo-reference", dataSubsetName: "")
     }
     
+    init(lookup: EnrichmentLookup) {
+        self.results = nil
+        super.init(smartyKey: lookup.getSmartyKey(), datasetName: "geo-reference", dataSubsetName: "")
+        for key in lookup.getIncludeAttributes() {
+            self.addIncludeAttribute(attribute: key)
+        }
+        for key in lookup.getExcludeAttributes() {
+            self.addExcludeAttribute(attribute: key)
+        }
+        self.setStreet(street: lookup.getStreet())
+        self.setCity(city: lookup.getCity())
+        self.setState(state: lookup.getState())
+        self.setZipcode(zipcode: lookup.getZipcode())
+        self.setFreeform(freeform: lookup.getFreeform())
+        self.setEtag(etag: lookup.getEtag())
+    }
+    
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {
         self.results = serializer.Deserialize(payload: payload, error: &error.pointee) as? [GeoReferenceResult]
     }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyFinancialEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyFinancialEnrichmentLookup.swift
@@ -9,6 +9,23 @@ public class PropertyFinancialEnrichmentLookup: EnrichmentLookup {
         super.init(smartyKey: smartyKey, datasetName: "property", dataSubsetName: "financial")
     }
     
+    init(lookup: EnrichmentLookup) {
+        self.results = nil
+        super.init(smartyKey: lookup.getSmartyKey(), datasetName: "property", dataSubsetName: "financial")
+        for key in lookup.getIncludeAttributes() {
+            self.addIncludeAttribute(attribute: key)
+        }
+        for key in lookup.getExcludeAttributes() {
+            self.addExcludeAttribute(attribute: key)
+        }
+        self.setStreet(street: lookup.getStreet())
+        self.setCity(city: lookup.getCity())
+        self.setState(state: lookup.getState())
+        self.setZipcode(zipcode: lookup.getZipcode())
+        self.setFreeform(freeform: lookup.getFreeform())
+        self.setEtag(etag: lookup.getEtag())
+    }
+    
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {
         self.results = serializer.Deserialize(payload: payload, error: &error.pointee) as? [FinancialResult]
     }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyFinancialEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyFinancialEnrichmentLookup.swift
@@ -24,6 +24,9 @@ public class PropertyFinancialEnrichmentLookup: EnrichmentLookup {
         self.setZipcode(zipcode: lookup.getZipcode())
         self.setFreeform(freeform: lookup.getFreeform())
         self.setEtag(etag: lookup.getEtag())
+        for key in lookup.getCustomParamArray().keys {
+            self.addCustomParameter(parameter: key, value: lookup.getCustomParamArray()[key] ?? "")
+        }
     }
     
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyPrincipalEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyPrincipalEnrichmentLookup.swift
@@ -9,6 +9,23 @@ public class PropertyPrincipalEnrichmentLookup: EnrichmentLookup {
         super.init(smartyKey: smartyKey, datasetName: "property", dataSubsetName: "principal")
     }
     
+    init(lookup: EnrichmentLookup) {
+        self.results = nil
+        super.init(smartyKey: lookup.getSmartyKey(), datasetName: "property", dataSubsetName: "principal")
+        for key in lookup.getIncludeAttributes() {
+            self.addIncludeAttribute(attribute: key)
+        }
+        for key in lookup.getExcludeAttributes() {
+            self.addExcludeAttribute(attribute: key)
+        }
+        self.setStreet(street: lookup.getStreet())
+        self.setCity(city: lookup.getCity())
+        self.setState(state: lookup.getState())
+        self.setZipcode(zipcode: lookup.getZipcode())
+        self.setFreeform(freeform: lookup.getFreeform())
+        self.setEtag(etag: lookup.getEtag())
+    }
+    
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {
         self.results = serializer.Deserialize(payload: payload, error: &error.pointee) as? [PrincipalResult]
     }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyPrincipalEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/PropertyPrincipalEnrichmentLookup.swift
@@ -24,6 +24,9 @@ public class PropertyPrincipalEnrichmentLookup: EnrichmentLookup {
         self.setZipcode(zipcode: lookup.getZipcode())
         self.setFreeform(freeform: lookup.getFreeform())
         self.setEtag(etag: lookup.getEtag())
+        for key in lookup.getCustomParamArray().keys {
+            self.addCustomParameter(parameter: key, value: lookup.getCustomParamArray()[key] ?? "")
+        }
     }
     
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryCountEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryCountEnrichmentLookup.swift
@@ -9,6 +9,23 @@ public class SecondaryCountEnrichmentLookup: EnrichmentLookup {
         super.init(smartyKey: smartyKey, datasetName: "secondary", dataSubsetName: "count")
     }
     
+    init(lookup: EnrichmentLookup) {
+        self.results = nil
+        super.init(smartyKey: lookup.getSmartyKey(), datasetName: "secondary", dataSubsetName: "count")
+        for key in lookup.getIncludeAttributes() {
+            self.addIncludeAttribute(attribute: key)
+        }
+        for key in lookup.getExcludeAttributes() {
+            self.addExcludeAttribute(attribute: key)
+        }
+        self.setStreet(street: lookup.getStreet())
+        self.setCity(city: lookup.getCity())
+        self.setState(state: lookup.getState())
+        self.setZipcode(zipcode: lookup.getZipcode())
+        self.setFreeform(freeform: lookup.getFreeform())
+        self.setEtag(etag: lookup.getEtag())
+    }
+    
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {
         self.results = serializer.Deserialize(payload: payload, error: &error.pointee) as? [SecondaryCountResult]
     }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryCountEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryCountEnrichmentLookup.swift
@@ -24,6 +24,9 @@ public class SecondaryCountEnrichmentLookup: EnrichmentLookup {
         self.setZipcode(zipcode: lookup.getZipcode())
         self.setFreeform(freeform: lookup.getFreeform())
         self.setEtag(etag: lookup.getEtag())
+        for key in lookup.getCustomParamArray().keys {
+            self.addCustomParameter(parameter: key, value: lookup.getCustomParamArray()[key] ?? "")
+        }
     }
     
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryEnrichmentLookup.swift
@@ -9,6 +9,23 @@ public class SecondaryEnrichmentLookup: EnrichmentLookup {
         super.init(smartyKey: smartyKey, datasetName: "secondary", dataSubsetName: "")
     }
     
+    init(lookup: EnrichmentLookup) {
+        self.results = nil
+        super.init(smartyKey: lookup.getSmartyKey(), datasetName: "secondary", dataSubsetName: "")
+        for key in lookup.getIncludeAttributes() {
+            self.addIncludeAttribute(attribute: key)
+        }
+        for key in lookup.getExcludeAttributes() {
+            self.addExcludeAttribute(attribute: key)
+        }
+        self.setStreet(street: lookup.getStreet())
+        self.setCity(city: lookup.getCity())
+        self.setState(state: lookup.getState())
+        self.setZipcode(zipcode: lookup.getZipcode())
+        self.setFreeform(freeform: lookup.getFreeform())
+        self.setEtag(etag: lookup.getEtag())
+    }
+    
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {
         self.results = serializer.Deserialize(payload: payload, error: &error.pointee) as? [SecondaryResult]
     }

--- a/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryEnrichmentLookup.swift
+++ b/Sources/SmartyStreets/USEnrichment/LookupTypes/SecondaryEnrichmentLookup.swift
@@ -24,6 +24,9 @@ public class SecondaryEnrichmentLookup: EnrichmentLookup {
         self.setZipcode(zipcode: lookup.getZipcode())
         self.setFreeform(freeform: lookup.getFreeform())
         self.setEtag(etag: lookup.getEtag())
+        for key in lookup.getCustomParamArray().keys {
+            self.addCustomParameter(parameter: key, value: lookup.getCustomParamArray()[key] ?? "")
+        }
     }
     
     override public func deserializeAndSetResults(serializer: SmartySerializer, payload: Data, error: UnsafeMutablePointer<NSError?>) {

--- a/Sources/SmartyStreets/USEnrichment/USEnrichmentClient.swift
+++ b/Sources/SmartyStreets/USEnrichment/USEnrichmentClient.swift
@@ -197,6 +197,9 @@ public class USEnrichmentClient: NSObject {
         if (lookup.getFreeform() != "") {
             request.setValue(value: lookup.getFreeform(), HTTPParameterField: "freeform")
         }
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
         return request
     }
     

--- a/Sources/SmartyStreets/USExtract/USExtractClient.swift
+++ b/Sources/SmartyStreets/USExtract/USExtractClient.swift
@@ -51,6 +51,9 @@ import Foundation
         if lookup.match != USExtractLookup.MatchStrategy.strict {
             request.setValue(value: lookup.match?.rawValue ?? "", HTTPParameterField: "match")
         }
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
         return request
     }
 }

--- a/Sources/SmartyStreets/USExtract/USExtractLookup.swift
+++ b/Sources/SmartyStreets/USExtract/USExtractLookup.swift
@@ -12,6 +12,7 @@ import Foundation
         case enhanced
     }
     
+    private var customParamArray: [String: String] = [:]
     public var result:USExtractResult?
     public var html:Bool?
     public var aggressive:Bool?
@@ -54,5 +55,13 @@ import Foundation
         } else {
             return false
         }
+    }
+    
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
 }

--- a/Sources/SmartyStreets/USReverseGeo/USReverseGeoClient.swift
+++ b/Sources/SmartyStreets/USReverseGeo/USReverseGeoClient.swift
@@ -38,6 +38,9 @@ public class USReverseGeoClient: NSObject {
         request.setValue(value: lookup.latitude, HTTPParameterField: "latitude")
         request.setValue(value: lookup.longitude, HTTPParameterField: "longitude")
         request.setValue(value: lookup.source, HTTPParameterField: "source")
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
 
         return request
     }

--- a/Sources/SmartyStreets/USReverseGeo/USReverseGeoLookup.swift
+++ b/Sources/SmartyStreets/USReverseGeo/USReverseGeoLookup.swift
@@ -6,6 +6,7 @@ import Foundation
     //
     //    See "https://smartystreets.com/docs/cloud/us-reverse-geo-api"
     
+    private var customParamArray: [String: String] = [:]
     public var latitude:String
     public var longitude:String
     public var source:String
@@ -15,5 +16,13 @@ import Foundation
         self.latitude = String(format: "%.8f", latitude)
         self.longitude = String(format: "%.8f", longitude)
         self.source = source
+    }
+    
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
 }

--- a/Sources/SmartyStreets/USStreet/USStreetClient.swift
+++ b/Sources/SmartyStreets/USStreet/USStreetClient.swift
@@ -80,8 +80,12 @@ public class USStreetClient: NSObject {
         populate(value: lookup.lastline, field: "lastline", request: request)
         populate(value: lookup.addressee, field: "addressee", request: request)
         populate(value: lookup.urbanization, field: "urbanization", request: request)
+        populate(value: lookup.countySource, field: "county_source", request: request)
         populate(value: lookup.matchStrategy, field: "match", request: request)
         populate(value: lookup.outputFormat, field: "format", request: request)
+        for key in lookup.getCustomParamArray().keys {
+            populate(value: lookup.getCustomParamArray()[key], field: key, request: request)
+        }
 
     }
     

--- a/Sources/SmartyStreets/USStreet/USStreetLookup.swift
+++ b/Sources/SmartyStreets/USStreet/USStreetLookup.swift
@@ -8,6 +8,7 @@ import Foundation
     //
     //    match: Must be set to 'strict', 'enhanced', or 'invalid'.
     
+    private var customParamArray: [String: String] = [:]
     public var result:[USStreetCandidate]!
     public var inputId:String?
     public var street:String?
@@ -20,6 +21,7 @@ import Foundation
     public var addressee:String?
     public var urbanization:String?
     public var maxCandidates:Int?
+    public var countySource:String?
     public var objcMaxCandidates:NSNumber? {
         get {
             return maxCandidates as NSNumber?
@@ -47,6 +49,14 @@ import Foundation
         return self.result[index]
     }
     
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
+    }
+    
     public func setMaxCandidates(max:Int, error: inout NSError?) {
         if max > 0 {
             self.maxCandidates = max
@@ -70,6 +80,7 @@ import Foundation
         dictionary = addValueToDictionary(value: self.addressee, key: "addressee", dictionary: dictionary)
         dictionary = addValueToDictionary(value: self.urbanization, key: "urbanization", dictionary: dictionary)
         dictionary = addValueToDictionary(value: self.maxCandidates, key: "candidates", dictionary: dictionary)
+        dictionary = addValueToDictionary(value: self.countySource, key: "county_source", dictionary: dictionary)
         dictionary = addValueToDictionary(value: self.matchStrategy, key: "match", dictionary: dictionary)
         dictionary = addValueToDictionary(value: self.outputFormat, key: "format", dictionary: dictionary)
         return dictionary

--- a/Sources/SmartyStreets/USZipCode/USZipCodeClient.swift
+++ b/Sources/SmartyStreets/USZipCode/USZipCodeClient.swift
@@ -68,6 +68,9 @@ import Foundation
         populate(value: lookup.city, field: "city", request: request)
         populate(value: lookup.state, field: "state", request: request)
         populate(value: lookup.zipcode, field: "zipcode", request: request)
+        for key in lookup.getCustomParamArray().keys {
+            populate(value: lookup.getCustomParamArray()[key], field: key, request: request)
+        }
     }
     
     func populate(value:String!, field:String, request:SmartyRequest) {

--- a/Sources/SmartyStreets/USZipCode/USZipCodeLookup.swift
+++ b/Sources/SmartyStreets/USZipCode/USZipCodeLookup.swift
@@ -6,6 +6,7 @@ import Foundation
     //
     //    See "https://smartystreets.com/docs/cloud/us-zipcode-api#http-request-input-fields"
     
+    private var customParamArray: [String: String] = [:]
     public var result:USZipCodeResult!
     public var inputId:String?
     public var city:String?
@@ -35,6 +36,14 @@ import Foundation
         } else {
             self.inputId = nil
         }
+    }
+    
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+    
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
     }
     
     public func toDictionary() -> NSDictionary {

--- a/Tests/SmartyStreetsTests/InternationalAutocompleteTests/InternationalAutocompleteClientTests.swift
+++ b/Tests/SmartyStreetsTests/InternationalAutocompleteTests/InternationalAutocompleteClientTests.swift
@@ -29,6 +29,7 @@ class InternationalAutocompleteClientTests: XCTestCase {
         lookup.maxResults = 4
         lookup.postalCode = "5"
         lookup.addressID = "6"
+        lookup.addCustomParameter(parameter: "custom", value: "7")
         
         _ = client.sendLookup(lookup:&lookup, error:&error)
         
@@ -38,6 +39,7 @@ class InternationalAutocompleteClientTests: XCTestCase {
         XCTAssertEqual("4", capturingSender.request.parameters["max_results"])
         XCTAssertEqual("5", capturingSender.request.parameters["include_only_postal_code"])
         XCTAssertEqual("http://localhost/6", capturingSender.request.urlPrefix)
+        XCTAssertEqual("7", capturingSender.request.parameters["custom"])
         XCTAssertNil(self.error)
     }
 

--- a/Tests/SmartyStreetsTests/InternationalStreetTests/InternationalStreetClientTests.swift
+++ b/Tests/SmartyStreetsTests/InternationalStreetTests/InternationalStreetClientTests.swift
@@ -51,11 +51,23 @@ class InternationalStreetClientTests: XCTestCase {
         lookup.locality = "7"
         lookup.administrativeArea = "8"
         lookup.postalCode = "9"
+        lookup.addCustomParameter(parameter: "custom", value: "10")
         
         _ = client.sendLookup(lookup: &lookup, error: &self.error)
         
         XCTAssertNil(self.error)
         XCTAssertNotNil(capturingSender.request.getUrl())
+        XCTAssertEqual("0" , capturingSender.request.parameters["country"])
+        XCTAssertEqual("1" , capturingSender.request.parameters["freeform"])
+        XCTAssertEqual("2" , capturingSender.request.parameters["address1"])
+        XCTAssertEqual("3" , capturingSender.request.parameters["address2"])
+        XCTAssertEqual("4" , capturingSender.request.parameters["address3"])
+        XCTAssertEqual("5" , capturingSender.request.parameters["address4"])
+        XCTAssertEqual("6" , capturingSender.request.parameters["organization"])
+        XCTAssertEqual("7" , capturingSender.request.parameters["locality"])
+        XCTAssertEqual("8" , capturingSender.request.parameters["administrative_area"])
+        XCTAssertEqual("9" , capturingSender.request.parameters["postal_code"])
+        XCTAssertEqual("10" , capturingSender.request.parameters["custom"])
     }
     
     func testEmptyLookupRejected() {

--- a/Tests/SmartyStreetsTests/SerializerTests.swift
+++ b/Tests/SmartyStreetsTests/SerializerTests.swift
@@ -76,7 +76,7 @@ class SerializerTests: XCTestCase {
     
     func testSerialize() {
         let expectedOutput = """
-        [{"city":"01","inputId":"04","state":"02","zipcode":"03"},{"city":"05","inputId":"08","state":"06","zipcode":"07"}]
+        [{"city":"01","customParamArray":{},"inputId":"04","state":"02","zipcode":"03"},{"city":"05","customParamArray":{},"inputId":"08","state":"06","zipcode":"07"}]
         """
         let lookup1 = USZipCodeLookup(city: "01", state: "02", zipcode: "03", inputId: "04")
         let lookup2 = USZipCodeLookup(city: "05", state: "06", zipcode: "07", inputId: "08")

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/FinancialResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/FinancialResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentFinancialResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"city":"2","data_set_name":"property","data_subset_name":"financial","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
+        {"city":"2","custom_param_array":{},"data_set_name":"property","data_subset_name":"financial","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/FinancialResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/FinancialResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentFinancialResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"data_set_name":"property","data_subset_name":"financial","smarty_key":"xxx"}
+        {"city":"2","data_set_name":"property","data_subset_name":"financial","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """
@@ -27,7 +27,20 @@ class USEnrichmentFinancialResultTest: XCTestCase {
     }
     
     func testSerialization() {
-        let lookup = PropertyFinancialEnrichmentLookup(smartyKey: "xxx")
+        let inputLookup = EnrichmentLookup()
+        inputLookup.setSmartyKey(smarty_key: "xxx")
+        inputLookup.setStreet(street: "1")
+        inputLookup.setCity(city: "2")
+        inputLookup.setState(state: "3")
+        inputLookup.setZipcode(zipcode: "4")
+        inputLookup.setFreeform(freeform: "5")
+        inputLookup.setEtag(etag: "6")
+        inputLookup.addIncludeAttribute(attribute: "7")
+        inputLookup.addIncludeAttribute(attribute: "8")
+        inputLookup.addExcludeAttribute(attribute: "9")
+        inputLookup.addExcludeAttribute(attribute: "10")
+        
+        let lookup = PropertyFinancialEnrichmentLookup(lookup: inputLookup)
         let actualBytes = serializer.Serialize(obj: lookup, error: &self.error)
         
         let data = Data(base64Encoded: (actualBytes?.base64EncodedString())!)

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/GeoReferenceResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/GeoReferenceResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentGeoReferenceResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"city":"2","data_set_name":"geo-reference","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
+        {"city":"2","custom_param_array":{},"data_set_name":"geo-reference","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/GeoReferenceResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/GeoReferenceResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentGeoReferenceResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"data_set_name":"geo-reference","data_subset_name":"","smarty_key":"xxx"}
+        {"city":"2","data_set_name":"geo-reference","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """
@@ -56,7 +56,20 @@ class USEnrichmentGeoReferenceResultTest: XCTestCase {
     }
     
     func testSerialization() {
-        let lookup = GeoReferenceEnrichmentLookup(smartyKey: "xxx")
+        let inputLookup = EnrichmentLookup()
+        inputLookup.setSmartyKey(smarty_key: "xxx")
+        inputLookup.setStreet(street: "1")
+        inputLookup.setCity(city: "2")
+        inputLookup.setState(state: "3")
+        inputLookup.setZipcode(zipcode: "4")
+        inputLookup.setFreeform(freeform: "5")
+        inputLookup.setEtag(etag: "6")
+        inputLookup.addIncludeAttribute(attribute: "7")
+        inputLookup.addIncludeAttribute(attribute: "8")
+        inputLookup.addExcludeAttribute(attribute: "9")
+        inputLookup.addExcludeAttribute(attribute: "10")
+        
+        let lookup = GeoReferenceEnrichmentLookup(lookup: inputLookup)
         let actualBytes = serializer.Serialize(obj: lookup, error: &self.error)
         
         let data = Data(base64Encoded: (actualBytes?.base64EncodedString())!)

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/PrincipalResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/PrincipalResultTest.swift
@@ -14,7 +14,7 @@ class USEnrichmentPrincipalResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"city":"2","data_set_name":"property","data_subset_name":"principal","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
+        {"city":"2","custom_param_array":{},"data_set_name":"property","data_subset_name":"principal","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
     
         

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/PrincipalResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/PrincipalResultTest.swift
@@ -14,7 +14,7 @@ class USEnrichmentPrincipalResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"data_set_name":"property","data_subset_name":"principal","smarty_key":"xxx"}
+        {"city":"2","data_set_name":"property","data_subset_name":"principal","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
     
         
@@ -31,7 +31,20 @@ class USEnrichmentPrincipalResultTest: XCTestCase {
     }
     
     func testLookupSerialization() {
-        let lookup = PropertyPrincipalEnrichmentLookup(smartyKey: "xxx")
+        let inputLookup = EnrichmentLookup()
+        inputLookup.setSmartyKey(smarty_key: "xxx")
+        inputLookup.setStreet(street: "1")
+        inputLookup.setCity(city: "2")
+        inputLookup.setState(state: "3")
+        inputLookup.setZipcode(zipcode: "4")
+        inputLookup.setFreeform(freeform: "5")
+        inputLookup.setEtag(etag: "6")
+        inputLookup.addIncludeAttribute(attribute: "7")
+        inputLookup.addIncludeAttribute(attribute: "8")
+        inputLookup.addExcludeAttribute(attribute: "9")
+        inputLookup.addExcludeAttribute(attribute: "10")
+        
+        let lookup = PropertyPrincipalEnrichmentLookup(lookup: inputLookup)
         let actualBytes = serializer.Serialize(obj: lookup, error: &self.error)
         
         let data = Data(base64Encoded: (actualBytes?.base64EncodedString())!)

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryCountResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryCountResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentSecondaryCountResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"city":"2","data_set_name":"secondary","data_subset_name":"count","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
+        {"city":"2","custom_param_array":{},"data_set_name":"secondary","data_subset_name":"count","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryCountResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryCountResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentSecondaryCountResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"data_set_name":"secondary","data_subset_name":"count","smarty_key":"xxx"}
+        {"city":"2","data_set_name":"secondary","data_subset_name":"count","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """
@@ -32,7 +32,20 @@ class USEnrichmentSecondaryCountResultTest: XCTestCase {
     }
     
     func testSerialization() {
-        let lookup = SecondaryCountEnrichmentLookup(smartyKey: "xxx")
+        let inputLookup = EnrichmentLookup()
+        inputLookup.setSmartyKey(smarty_key: "xxx")
+        inputLookup.setStreet(street: "1")
+        inputLookup.setCity(city: "2")
+        inputLookup.setState(state: "3")
+        inputLookup.setZipcode(zipcode: "4")
+        inputLookup.setFreeform(freeform: "5")
+        inputLookup.setEtag(etag: "6")
+        inputLookup.addIncludeAttribute(attribute: "7")
+        inputLookup.addIncludeAttribute(attribute: "8")
+        inputLookup.addExcludeAttribute(attribute: "9")
+        inputLookup.addExcludeAttribute(attribute: "10")
+        
+        let lookup = SecondaryCountEnrichmentLookup(lookup: inputLookup)
         let actualBytes = serializer.Serialize(obj: lookup, error: &self.error)
         
         let data = Data(base64Encoded: (actualBytes?.base64EncodedString())!)

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentSecondaryResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"city":"2","data_set_name":"secondary","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
+        {"city":"2","custom_param_array":{},"data_set_name":"secondary","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryResultTest.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/SecondaryResultTest.swift
@@ -12,7 +12,7 @@ class USEnrichmentSecondaryResultTest: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        {"data_set_name":"secondary","data_subset_name":"","smarty_key":"xxx"}
+        {"city":"2","data_set_name":"secondary","data_subset_name":"","etag":"6","exclude_array":["9","10"],"freeform":"5","include_array":["7","8"],"smarty_key":"xxx","state":"3","street":"1","zipcode":"4"}
         """
         
         sobj = """
@@ -84,7 +84,20 @@ class USEnrichmentSecondaryResultTest: XCTestCase {
     }
     
     func testSerialization() {
-        let lookup = SecondaryEnrichmentLookup(smartyKey: "xxx")
+        let inputLookup = EnrichmentLookup()
+        inputLookup.setSmartyKey(smarty_key: "xxx")
+        inputLookup.setStreet(street: "1")
+        inputLookup.setCity(city: "2")
+        inputLookup.setState(state: "3")
+        inputLookup.setZipcode(zipcode: "4")
+        inputLookup.setFreeform(freeform: "5")
+        inputLookup.setEtag(etag: "6")
+        inputLookup.addIncludeAttribute(attribute: "7")
+        inputLookup.addIncludeAttribute(attribute: "8")
+        inputLookup.addExcludeAttribute(attribute: "9")
+        inputLookup.addExcludeAttribute(attribute: "10")
+        
+        let lookup = SecondaryEnrichmentLookup(lookup: inputLookup)
         let actualBytes = serializer.Serialize(obj: lookup, error: &self.error)
         
         let data = Data(base64Encoded: (actualBytes?.base64EncodedString())!)

--- a/Tests/SmartyStreetsTests/USReverseGeoTests/USReverseGeoSerializerTests.swift
+++ b/Tests/SmartyStreetsTests/USReverseGeoTests/USReverseGeoSerializerTests.swift
@@ -42,7 +42,7 @@ class USReverseGeoSerializerTests: XCTestCase {
     
     func testSerialize() {
         let expectedOutput = """
-        {"latitude":"44.88888889","longitude":"-111.11111111","source":""}
+        {"customParamArray":{},"latitude":"44.88888889","longitude":"-111.11111111","source":""}
         """
         
         let lookup = USReverseGeoLookup(latitude: 44.888888888, longitude: -111.111111111, source: "")

--- a/Tests/SmartyStreetsTests/USStreetTests/USStreetCandidateTests.swift
+++ b/Tests/SmartyStreetsTests/USStreetTests/USStreetCandidateTests.swift
@@ -10,7 +10,7 @@ class USStreetCandidateTests: XCTestCase {
     override func setUp() {
         super.setUp()
         expectedJsonInput = """
-        [{\"addressee\":\"addressee_value\",\"city\":\"city_value\",\"lastline\":\"lastline_value\",\"matchStrategy\":\"match_value\",\"maxCandidates\":5,\"result\":[],\"secondary\":\"secondary\",\"state\":\"state_value\",\"street\":\"street_value\",\"street2\":\"street2_value\",\"urbanization\":\"urbanization_value\",\"zipCode\":\"zipCode_value\"},{\"city\":\"Mountain view\",\"maxCandidates\":1,\"result\":[],\"state\":\"California\",\"street\":\"1600 amphitheatre parkway\"},{\"maxCandidates\":1,\"result\":[],\"street\":\"1 Rosedale, Baltimore, Maryland\"}]
+        [{\"addressee\":\"addressee_value\",\"city\":\"city_value\",\"customParamArray\":{},\"lastline\":\"lastline_value\",\"matchStrategy\":\"match_value\",\"maxCandidates\":5,\"result\":[],\"secondary\":\"secondary\",\"state\":\"state_value\",\"street\":\"street_value\",\"street2\":\"street2_value\",\"urbanization\":\"urbanization_value\",\"zipCode\":\"zipCode_value\"},{\"city\":\"Mountain view\",\"customParamArray\":{},\"maxCandidates\":1,\"result\":[],\"state\":\"California\",\"street\":\"1600 amphitheatre parkway\"},{\"customParamArray\":{},\"maxCandidates\":1,\"result\":[],\"street\":\"1 Rosedale, Baltimore, Maryland\"}]
         """
         
         obj = [

--- a/Tests/SmartyStreetsTests/USZipCodeTests/USZipCodeClientTests.swift
+++ b/Tests/SmartyStreetsTests/USZipCodeTests/USZipCodeClientTests.swift
@@ -39,6 +39,7 @@ class USZipCodeClientTests: XCTestCase {
     func testSendingSingleFullyPopulatedLookup() {
         let client = USZipCodeClient(sender: self.sender as Any, serializer: self.serializer)
         var lookup = USZipCodeLookup(city: "1", state: "2", zipcode: "3", inputId: "4")
+        lookup.addCustomParameter(parameter: "custom", value: "5")
         
         _ = client.sendLookup(lookup: &lookup, error: &self.error)
         
@@ -46,6 +47,7 @@ class USZipCodeClientTests: XCTestCase {
         XCTAssertTrue(url.contains("zipcode=3"))
         XCTAssertTrue(url.contains("state=2"))
         XCTAssertTrue(url.contains("city=1"))
+        XCTAssertTrue(url.contains("custom=5"))
     }
     
     func testEmptyBatchNotSent() {

--- a/samples/Sources/swiftExamples/InternationalAutocompleteExample.swift
+++ b/samples/Sources/swiftExamples/InternationalAutocompleteExample.swift
@@ -10,12 +10,14 @@ class InternationalAutocompleteExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses: ["international-autocomplete-cloud"]).buildInternationalAutocompleteApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildInternationalAutocompleteApiClient()
 
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses: ["international-autocomplete-v2-cloud"]).buildInternationalAutocompleteApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildInternationalAutocompleteApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses: ["international-autocomplete-v2-cloud"]).buildInternationalAutocompleteApiClient()
         
         // Documentation for input fields can be found at:
         // https://smartystreets.com/docs/cloud/international-address-autocomplete-api#http-input-fields
@@ -24,6 +26,9 @@ class InternationalAutocompleteExample {
         lookup.country = "FRA"
         lookup.locality = "Paris"
         lookup.search = "Louis"
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         var error: NSError! = nil
         

--- a/samples/Sources/swiftExamples/InternationalStreetExample.swift
+++ b/samples/Sources/swiftExamples/InternationalStreetExample.swift
@@ -10,12 +10,14 @@ class InternationalStreetExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses: ["international-global-plus-cloud"]).buildInternationalStreetApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildInternationalStreetApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses: ["international-global-plus-cloud"]).buildInternationalStreetApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildInternationalStreetApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses: ["international-global-plus-cloud"]).buildInternationalStreetApiClient()
         
         // Documentation for input fields can be found at:
         // https://smartystreets.com/docs/cloud/international-street-api#http-input-fields
@@ -30,6 +32,9 @@ class InternationalStreetExample {
         lookup.country = "Brazil"
         lookup.postalCode = "02516-050"
         lookup.enableGeocode(geocode: true)
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         var error: NSError! = nil
         

--- a/samples/Sources/swiftExamples/USAutocompleteProExample.swift
+++ b/samples/Sources/swiftExamples/USAutocompleteProExample.swift
@@ -10,17 +10,22 @@ class USAutocompleteProExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses:["us-autocomplete-pro-cloud"]).buildUSAutocompleteProApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildUSAutocompleteProApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-autocomplete-pro-cloud"]).buildUSAutocompleteProApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildUSAutocompleteProApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-autocomplete-pro-cloud"]).buildUSAutocompleteProApiClient()
         
         //            Documentation for input fields can be found at:
         //            https://smartystreets.com/docs/cloud/us-autocomplete-api#pro-http-request-input-fields
 
         var lookup = USAutocompleteProLookup().withSearch(search: "1042 W Center")
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         var error:NSError! = nil
         

--- a/samples/Sources/swiftExamples/USEnrichmentExample.swift
+++ b/samples/Sources/swiftExamples/USEnrichmentExample.swift
@@ -12,18 +12,12 @@ class USEnrichmentExample{
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let credentials = [authId, authToken]
-        
-        //let client = ClientBuilder(authId: credentials[0], authToken: credentials[1]).buildUsEnrichmentApiClient()
-        // Uncomment the Above line to make a call with secret keys, and uncomment the below line do so wtih a license value:
-        //let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).with_licenses([<insert license string here]).buildUsEnrichmentApiClient()
+        //let client = ClientBuilder(authId: authId, authToken: authToken).buildUsEnrichmentApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let credentials = [id, hostname]
-        
-        let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).buildUsEnrichmentApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildUsEnrichmentApiClient()
         // Comment the Above line, and uncomment the below line to explicitly specify a license value:
         //let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).with_licenses([<insert license string here]).buildUsEnrichmentApiClient()
         
@@ -51,6 +45,9 @@ class USEnrichmentExample{
         
         // Uncomment the below line to add an Etag header to a lookup:
         //lookup.setEtag(etag: "AUBAGDQDAIGQYCYC")
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         let lookupType = "principal"
         

--- a/samples/Sources/swiftExamples/USEnrichmentExample.swift
+++ b/samples/Sources/swiftExamples/USEnrichmentExample.swift
@@ -12,19 +12,68 @@ class USEnrichmentExample{
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
+        //let credentials = [authId, authToken]
+        
+        //let client = ClientBuilder(authId: credentials[0], authToken: credentials[1]).buildUsEnrichmentApiClient()
+        // Uncomment the Above line to make a call with secret keys, and uncomment the below line do so wtih a license value:
+        //let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).with_licenses([<insert license string here]).buildUsEnrichmentApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: "SMARTY_AUTH_WEB", hostname: "SMARTY_AUTH_REFERER").withLicenses(licenses: ["us-property-data-principal-cloud"])
-            .buildUsEnrichmentApiClient()
-
-        let smartyKey = "325023201"
+        let credentials = [id, hostname]
+        
+        let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).buildUsEnrichmentApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: credentials[0], hostname: credentials[1]).with_licenses([<insert license string here]).buildUsEnrichmentApiClient()
+        
+        let smartyKey = ""
+        // Comment the above line, and uncomment the below line to make a call with ONLY a SmartyKey
+        //let smartyKey = "325023201"
+        
+        let lookup = EnrichmentLookup()
+        lookup.setStreet(street: "56 Union Ave")
+        lookup.setCity(city: "Somerville")
+        lookup.setState(state: "NJ")
+        lookup.setZipcode(zipcode: "08876")
+        
+        // Uncomment the below line to make a call with SmartyKey:
+        //lookup.setSmartyKey(smarty_key: "325023201")
+        
+        // Uncomment the below line to set the freeform field on a lookup:
+        //lookup.setFreeform(freeform: "56 Union Ave Somerville NJ 08876")
+        
+        // Uncomment the below line to include an attribute in a lookup:
+        //lookup.addIncludeAttribute(attribute: "census_tract")
+        
+        // Uncomment the below line to exclude an attribute from a lookup:
+        //lookup.addExcludeAttribute(attribute: "census_tract")
+        
+        // Uncomment the below line to add an Etag header to a lookup:
+        //lookup.setEtag(etag: "AUBAGDQDAIGQYCYC")
         
         let lookupType = "principal"
         
-        if lookupType.lowercased() == "principal" {
+        if (smartyKey == "") {
+            if lookupType.lowercased() == "principal" {
+                let results = client.sendPropertyPrincipalLookup(inputLookup: lookup, error: &error)
+                return try self.outputPrincipalResults(results: [results?[0].attributes])
+            } else if lookupType.lowercased() == "financial" {
+                let results = client.sendPropertyFinancialLookup(inputLookup: lookup, error: &error)
+                return try self.outputFinancialResults(results: [results?[0].attributes])
+            } else if lookupType.lowercased() == "geo-reference" {
+                let results = client.sendGeoReferenceLookup(inputLookup: lookup, error: &error)
+                return try self.outputGeoReferenceResults(results: [results?[0].attributes])
+            } else if lookupType.lowercased() == "secondary" {
+                let results = client.sendSecondaryLookup(inputLookup: lookup, error: &error)
+                return try self.outputSecondaryResults(results: [results?[0]])
+            } else if lookupType.lowercased() == "secondary-count" {
+                let results = client.sendSecondaryCountLookup(inputLookup: lookup, error: &error)
+                return try self.outputSecondaryCountResults(results: [results?[0]])
+            }
+        // The following calls are made using ONLY a smarty key, and are not capable of accepting other parameters.
+        // Use a 'lookup' call, like those above, to make an API call with additional parameters.
+        } else if lookupType.lowercased() == "principal" {
             let results = client.sendPropertyPrincipalLookup(smartyKey: smartyKey, error: &error)
             return try self.outputPrincipalResults(results: [results?[0].attributes])
         } else if lookupType.lowercased() == "financial" {

--- a/samples/Sources/swiftExamples/USExtractExample.swift
+++ b/samples/Sources/swiftExamples/USExtractExample.swift
@@ -27,6 +27,10 @@ class USExtractExample {
         lookup.addressesHaveLineBreaks = false
         lookup.addressesPerLine = 1
         lookup.match = USExtractLookup.MatchStrategy.enhanced
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
+        
         var error: NSError! = nil
         
         _ = client.sendLookup(lookup: &lookup, error: &error)

--- a/samples/Sources/swiftExamples/USReverseGeoExample.swift
+++ b/samples/Sources/swiftExamples/USReverseGeoExample.swift
@@ -10,17 +10,22 @@ class USReverseGeoExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses:["us-reverse-geocoding-cloud"]).buildUsReverseGeoApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildUsReverseGeoApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-reverse-geocoding-cloud"]).buildUsReverseGeoApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildUsReverseGeoApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-reverse-geocoding-cloud"]).buildUsReverseGeoApiClient()
         
         // Documentation for input fields can be found at:
         // https://smartystreets.com/docs/cloud/us-reverse-geo-api#http-input-fields
         
         var lookup = USReverseGeoLookup(latitude: 40.27644, longitude: -111.65747, source: "postal")
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         var error: NSError! = nil
         

--- a/samples/Sources/swiftExamples/USStreetMultipleAddressExample.swift
+++ b/samples/Sources/swiftExamples/USStreetMultipleAddressExample.swift
@@ -10,12 +10,14 @@ class USStreetMultipleAddressExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildUsStreetApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildUsStreetApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
                 
         let batch = USStreetBatch()
         var error:NSError! = nil

--- a/samples/Sources/swiftExamples/USStreetSingleAddressExample.swift
+++ b/samples/Sources/swiftExamples/USStreetSingleAddressExample.swift
@@ -10,12 +10,14 @@ class USStreetSingleAddressExample {
         //            for server-to-server requests, use this code:
         //let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
         //let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
-        //let client = ClientBuilder(authId:authId, authToken:authToken).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
+        //let client = ClientBuilder(authId:authId, authToken:authToken).buildUsStreetApiClient()
         
         // for client-side requests (browser/mobile), use this code:
         let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
         let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
-        let client = ClientBuilder(id: id, hostname: hostname).withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
+        let client = ClientBuilder(id: id, hostname: hostname).buildUsStreetApiClient()
+        // Comment the Above line, and uncomment the below line to explicitly specify a license value:
+        //let client = ClientBuilder(id: id, hostname: hostname).withDebug().withLicenses(licenses:["us-core-cloud"]).buildUsStreetApiClient()
                 
         //        Documentation for input fields can be found at:
         //        https://smartystreets.com/docs/us-street-api#input-fields
@@ -33,6 +35,9 @@ class USStreetSingleAddressExample {
         lookup.matchStrategy = "invalid" // "invalid" is the most permissive match,
                                          // this will always return at least one result even if the address is invalid.
                                          // Refer to the documentation for additional Match Strategy options.
+        
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
         
         var error: NSError! = nil
         _ = client.sendLookup(lookup: &lookup, error: &error)

--- a/samples/Sources/swiftExamples/USZipCodeSingleLookupExample.swift
+++ b/samples/Sources/swiftExamples/USZipCodeSingleLookupExample.swift
@@ -22,6 +22,9 @@ class USZipCodeSingleLookupExample {
         lookup.state = "California"
         lookup.zipcode = "94043"
         
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
+        
         var error:NSError! = nil
         _ = client.sendLookup(lookup: &lookup, error: &error)
         


### PR DESCRIPTION
 - Added Address Search for the US Address Enrichment API
 - Added Etag header for the US Address Enrichment API
 - Added include and exclude parameters for the US Address Enrichment API
 - Added county_source parameter for the US Street Address API
 - Added custom parameter functionality for all APIs
 - Modified example ClientBuilder statements to avoid explicitly specifying a license value
 - Updated tests to reflect the above functionalities