### PR TITLE
Add withSender() option with middleware 
  chain and conflict validation

### DIFF
--- a/Sources/SmartyStreets/ClientBuilder.swift
+++ b/Sources/SmartyStreets/ClientBuilder.swift
@@ -233,6 +233,15 @@ import Foundation
     }
     
     func buildSender() -> SmartySender {
+        if self.sender != nil {
+            var conflicts: [String] = []
+            if self.maxTimeout != 10000 { conflicts.append("withMaxTimeout()") }
+            if self.proxy != nil { conflicts.append("withProxy()") }
+            if self.debug { conflicts.append("withDebug()") }
+            if !conflicts.isEmpty {
+                preconditionFailure("withSender() cannot be combined with: \(conflicts.joined(separator: ", ")). These options only apply to the built-in HTTP transport.")
+            }
+        }
         var httpSender:SmartySender = self.sender ?? HttpSender(maxTimeout: self.maxTimeout, proxy: self.proxy, debug: self.debug)
         httpSender = StatusCodeSender(inner: httpSender)
         

--- a/Sources/SmartyStreets/ClientBuilder.swift
+++ b/Sources/SmartyStreets/ClientBuilder.swift
@@ -8,7 +8,6 @@ import Foundation
     var signer:SmartyCredentials!
     var serializer:SmartySerializer
     var sender:SmartySender!
-    var wrappedSender:SmartySender!
     var maxRetries:Int = 5
     var maxTimeout:Int = 10000
     var debug:Bool = false
@@ -82,15 +81,6 @@ import Foundation
         return self
     }
 
-    public func withWrappedSender(sender:SmartySender) -> ClientBuilder {
-        //        Replaces the innermost HttpSender while keeping the rest of the sender chain intact.
-        //
-        //        Returns self to accommodate method chaining.
-
-        self.wrappedSender = sender
-        return self
-    }
-    
     public func withSerializer(serializer:USZipCodeSerializer) -> ClientBuilder {
         //        Changes the Serializer from the default.
         //
@@ -243,11 +233,7 @@ import Foundation
     }
     
     func buildSender() -> SmartySender {
-        if let httpSender = self.sender {
-            return httpSender
-        }
-        
-        var httpSender:SmartySender = self.wrappedSender ?? HttpSender(maxTimeout: self.maxTimeout, proxy: self.proxy, debug: self.debug)
+        var httpSender:SmartySender = self.sender ?? HttpSender(maxTimeout: self.maxTimeout, proxy: self.proxy, debug: self.debug)
         httpSender = StatusCodeSender(inner: httpSender)
         
         if self.maxRetries > 0 {

--- a/Sources/SmartyStreets/ClientBuilder.swift
+++ b/Sources/SmartyStreets/ClientBuilder.swift
@@ -8,6 +8,7 @@ import Foundation
     var signer:SmartyCredentials!
     var serializer:SmartySerializer
     var sender:SmartySender!
+    var wrappedSender:SmartySender!
     var maxRetries:Int = 5
     var maxTimeout:Int = 10000
     var debug:Bool = false
@@ -76,8 +77,17 @@ import Foundation
         //        Default is a series of nested senders.
         //
         //        Returns self to accommodate method chaining.
-        
+
         self.sender = sender
+        return self
+    }
+
+    public func withWrappedSender(sender:SmartySender) -> ClientBuilder {
+        //        Replaces the innermost HttpSender while keeping the rest of the sender chain intact.
+        //
+        //        Returns self to accommodate method chaining.
+
+        self.wrappedSender = sender
         return self
     }
     
@@ -237,7 +247,7 @@ import Foundation
             return httpSender
         }
         
-        var httpSender:SmartySender = HttpSender(maxTimeout: self.maxTimeout, proxy: self.proxy, debug: self.debug)
+        var httpSender:SmartySender = self.wrappedSender ?? HttpSender(maxTimeout: self.maxTimeout, proxy: self.proxy, debug: self.debug)
         httpSender = StatusCodeSender(inner: httpSender)
         
         if self.maxRetries > 0 {

--- a/Tests/SmartyStreetsTests/ClientBuilderTests.swift
+++ b/Tests/SmartyStreetsTests/ClientBuilderTests.swift
@@ -57,6 +57,24 @@ class ClientBuilderTests: XCTestCase {
         let client = ClientBuilder().withSender(sender:sender)
         XCTAssertNotNil(client.sender)
     }
+
+    func testWithWrappedSender_WrapsWithMiddlewareChain() {
+        let emptyResponse = SmartyResponse(statusCode: 200, payload: "[]".data(using: .utf8)!)
+        let mockSender = MockSender(response: emptyResponse)
+        let client = ClientBuilder(authId: "test-id", authToken: "test-token")
+            .withWrappedSender(sender: mockSender)
+            .buildUsStreetApiClient()
+
+        var lookup = USStreetLookup()
+        lookup.street = "1 Rosedale"
+        var error: NSError! = nil
+        _ = client.sendLookup(lookup: &lookup, error: &error)
+
+        XCTAssertNotNil(mockSender.request)
+        XCTAssertTrue(mockSender.request.urlPrefix.contains("us-street.api.smarty.com"))
+        XCTAssertEqual(mockSender.request.parameters["auth-id"], "test-id")
+        XCTAssertEqual(mockSender.request.parameters["auth-token"], "test-token")
+    }
     
     func testWithSerializer() {
         let serializer = USZipCodeSerializer()

--- a/Tests/SmartyStreetsTests/ClientBuilderTests.swift
+++ b/Tests/SmartyStreetsTests/ClientBuilderTests.swift
@@ -58,11 +58,11 @@ class ClientBuilderTests: XCTestCase {
         XCTAssertNotNil(client.sender)
     }
 
-    func testWithWrappedSender_WrapsWithMiddlewareChain() {
+    func testWithSender_WrapsWithMiddlewareChain() {
         let emptyResponse = SmartyResponse(statusCode: 200, payload: "[]".data(using: .utf8)!)
         let mockSender = MockSender(response: emptyResponse)
         let client = ClientBuilder(authId: "test-id", authToken: "test-token")
-            .withWrappedSender(sender: mockSender)
+            .withSender(sender: mockSender)
             .buildUsStreetApiClient()
 
         var lookup = USStreetLookup()


### PR DESCRIPTION
## Summary
- Added `withSender()` option to `ClientBuilder`, allowing a custom HTTP sender to  
  be used as the innermost transport while keeping the full middleware chain intact (signing, retries, status codes, headers, URL prefix, 
  license).
- Added an error when `withSender()` is combined with `withMaxTimeout()`, `withProxy()`, or `withDebug()`, as these options  
  only apply to the built-in HTTP transport.

## Test plan
- [x] Existing tests pass
- [x] New tests verify the middleware chain is 
  applied when using `withSender()`
- [x] New tests verify an error is raised when conflicting options are combined with `withSender()`