### PR TITLE
LanguageMode fixes

### DIFF
--- a/Sources/SmartyStreets/InternationalStreet/LanguageMode.swift
+++ b/Sources/SmartyStreets/InternationalStreet/LanguageMode.swift
@@ -2,11 +2,11 @@ import Foundation
 
 @objcMembers public class LanguageMode: NSObject, Codable {
     
-    var Native = "native"
-    var Latin = "latin"
-    var name:String
-    
-    init(name:String) {
+    public static let Native = "native"
+    public static let Latin = "latin"
+    public let name:String
+
+    public init(name:String) {
         self.name = name
     }
 }


### PR DESCRIPTION
LanguageMode Init wasn't public so people using this sdk couldn't use it properly. Fixed that and also changed the variables from var to public let because it's better swift format.