### PR TITLE
Surface API error messages and standardize HTTP status fallback messages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,9 @@ example-us-street-iana-timezone:
 example-us-enrichment:
 	@$(call run-example,USEnrichmentExample)
 
+example-us-enrichment-etag:
+	@$(call run-example,USEnrichmentEtagExample)
+
 # Run all examples
 examples-all:
 	@echo "Running all examples..."
@@ -80,6 +83,7 @@ examples-all:
 	@$(MAKE) example-us-reverse-geo
 	@$(MAKE) example-us-street-iana-timezone
 	@$(MAKE) example-us-enrichment
+	@$(MAKE) example-us-enrichment-etag
 	@echo "All examples completed!"
 
 compile:
@@ -99,4 +103,4 @@ publish: compile test version
 .PHONY: example-us-zipcode-single example-us-zipcode-multiple
 .PHONY: example-us-autocomplete-pro example-us-extract
 .PHONY: example-international-street example-international-autocomplete example-international-postal-code
-.PHONY: example-us-reverse-geo example-us-street-iana-timezone example-us-enrichment
+.PHONY: example-us-reverse-geo example-us-street-iana-timezone example-us-enrichment example-us-enrichment-etag

--- a/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteSerializer.swift
+++ b/Sources/SmartyStreets/InternationalAutocomplete/InternationalAutocompleteSerializer.swift
@@ -34,6 +34,10 @@ public class InternationalAutocompleteSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:InternationalAutocompleteResult = try jsonDecoder.decode(InternationalAutocompleteResult.self, from: payload!)

--- a/Sources/SmartyStreets/InternationalPostalCode/InternationalPostalCodeSerializer.swift
+++ b/Sources/SmartyStreets/InternationalPostalCode/InternationalPostalCodeSerializer.swift
@@ -31,6 +31,10 @@ class InternationalPostalCodeSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result: [InternationalPostalCodeCandidate] = try jsonDecoder.decode([InternationalPostalCodeCandidate].self, from: payload!)

--- a/Sources/SmartyStreets/InternationalStreet/InternationalStreetSerializer.swift
+++ b/Sources/SmartyStreets/InternationalStreet/InternationalStreetSerializer.swift
@@ -31,6 +31,10 @@ class InternationalStreetSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:[InternationalStreetCandidate] = try jsonDecoder.decode([InternationalStreetCandidate].self, from: payload!)

--- a/Sources/SmartyStreets/SmartyErrors.swift
+++ b/Sources/SmartyStreets/SmartyErrors.swift
@@ -19,10 +19,13 @@ class SmartyErrors {
         case BadRequestError = 400
         case BadCredentialsError = 401
         case PaymentRequiredError = 402
+        case ForbiddenError = 403
+        case RequestTimeoutError = 408
         case RequestEntityTooLargeError = 413
         case UnprocessableEntityError = 422
         case TooManyRequestsError = 429
         case InternalServerError = 500
+        case BadGatewayError = 502
         case ServiceUnavailableError = 503
         case GatewayTimeoutError = 504
     }

--- a/Sources/SmartyStreets/SmartySerializer.swift
+++ b/Sources/SmartyStreets/SmartySerializer.swift
@@ -12,6 +12,10 @@ public class SmartySerializer: NSObject {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result = try JSONSerialization.jsonObject(with: payload!, options: []) as? [String:Any]

--- a/Sources/SmartyStreets/StatusCodeSender.swift
+++ b/Sources/SmartyStreets/StatusCodeSender.swift
@@ -5,8 +5,8 @@ struct ResponseErrors : Codable {
 }
 
 struct ResponseError : Codable {
-    let id: Int
-    let message: String
+    let id: Int?
+    let message: String?
 }
 
 class StatusCodeSender: SmartySender {
@@ -27,14 +27,14 @@ class StatusCodeSender: SmartySender {
         case 200:
             return response
         case 304:
-            var details: [String:Any] = [NSLocalizedDescriptionKey: "Not Modified. This data has not been modified since it was last retrieved."]
+            var details: [String:Any] = [NSLocalizedDescriptionKey: "Not Modified: The requested record has not been modified since the previous request with the Etag value."]
             if let etag = extractResponseEtag(response: response) {
                 details[SmartyErrors.ResponseEtagKey] = etag
             }
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.NotModifiedInfo.rawValue, userInfo: details)
             return response
         case 400:
-            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.")]
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.BadRequestError.rawValue, userInfo: details)
             return nil
         case 401:
@@ -45,6 +45,14 @@ class StatusCodeSender: SmartySender {
             let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Payment Required: There is no active subscription for the account associated with the credentials submitted with the request.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.PaymentRequiredError.rawValue, userInfo: details)
             return nil
+        case 403:
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.")]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ForbiddenError.rawValue, userInfo: details)
+            return nil
+        case 408:
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Request timeout error.")]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.RequestTimeoutError.rawValue, userInfo: details)
+            return nil
         case 413:
             let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Request Entity Too Large: The request body has exceeded the maximum size.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.RequestEntityTooLargeError.rawValue, userInfo: details)
@@ -54,32 +62,29 @@ class StatusCodeSender: SmartySender {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.UnprocessableEntityError.rawValue, userInfo: details)
             return nil
         case 429:
-            var detailsStr = "Too Many Requests: " as String
-            do {
-                let errors = try self.jsonDecoder.decode(ResponseErrors.self, from: response!.payload)
-                for error in errors.errors {
-                    detailsStr.append(error.message)
-                }
-            } catch {
-                detailsStr.append("Error parsing response payload from server - ")
-                detailsStr.append(error.localizedDescription)
-            }
-            let details = [NSLocalizedDescriptionKey:detailsStr]
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Too Many Requests: The rate limit for your account has been exceeded.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.TooManyRequestsError.rawValue, userInfo: details)
             return response
         case 500:
-            let details = [NSLocalizedDescriptionKey:"Internal Server Error."]
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Internal Server Error.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.InternalServerError.rawValue, userInfo: details)
             return nil
+        case 502:
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Bad Gateway error.")]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.BadGatewayError.rawValue, userInfo: details)
+            return nil
         case 503:
-            let details = [NSLocalizedDescriptionKey:"Service Unavailable. Try again later."]
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Service Unavailable. Try again later.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ServiceUnavailableError.rawValue, userInfo: details)
             return nil
         case 504:
-            let details = [NSLocalizedDescriptionKey:"The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed."]
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.")]
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.GatewayTimeoutError.rawValue, userInfo: details)
             return nil
         default:
+            guard let response = response else { return nil }
+            let details = [NSLocalizedDescriptionKey:messageFrom(response: response, fallback: "The server returned an unexpected HTTP status code: \(response.statusCode)")]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: response.statusCode, userInfo: details)
             return nil
         }
     }
@@ -88,7 +93,7 @@ class StatusCodeSender: SmartySender {
         guard let errors = try? self.jsonDecoder.decode(ResponseErrors.self, from: response.payload) else {
             return fallback
         }
-        let message = errors.errors.map { $0.message }.joined(separator: " ")
+        let message = errors.errors.compactMap { $0.message }.filter { !$0.isEmpty }.joined(separator: " ")
         return message.isEmpty ? fallback : message
     }
 

--- a/Sources/SmartyStreets/StatusCodeSender.swift
+++ b/Sources/SmartyStreets/StatusCodeSender.swift
@@ -24,14 +24,7 @@ class StatusCodeSender: SmartySender {
         let smartyErrors = SmartyErrors()
         
         switch response?.statusCode {
-        case 200:
-            return response
-        case 304:
-            var details: [String:Any] = [NSLocalizedDescriptionKey: "Not Modified: The requested record has not been modified since the previous request with the Etag value."]
-            if let etag = extractResponseEtag(response: response) {
-                details[SmartyErrors.ResponseEtagKey] = etag
-            }
-            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.NotModifiedInfo.rawValue, userInfo: details)
+        case 200, 304:
             return response
         case 400:
             let details = [NSLocalizedDescriptionKey:messageFrom(response: response!, fallback: "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.")]
@@ -101,13 +94,4 @@ class StatusCodeSender: SmartySender {
         return (fallback + " Body: " + body).trimmingCharacters(in: .whitespaces)
     }
 
-    private func extractResponseEtag(response: SmartyResponse?) -> String? {
-        guard let response = response else { return nil }
-        for (key, value) in response.headers {
-            if key.caseInsensitiveCompare("Etag") == .orderedSame {
-                return value
-            }
-        }
-        return nil
-    }
 }

--- a/Sources/SmartyStreets/StatusCodeSender.swift
+++ b/Sources/SmartyStreets/StatusCodeSender.swift
@@ -90,11 +90,15 @@ class StatusCodeSender: SmartySender {
     }
 
     private func messageFrom(response: SmartyResponse, fallback: String) -> String {
-        guard let errors = try? self.jsonDecoder.decode(ResponseErrors.self, from: response.payload) else {
-            return fallback
+        if let errors = try? self.jsonDecoder.decode(ResponseErrors.self, from: response.payload) {
+            let message = errors.errors.compactMap { $0.message }.filter { !$0.isEmpty }.joined(separator: " ")
+            if !message.isEmpty {
+                return message
+            }
         }
-        let message = errors.errors.compactMap { $0.message }.filter { !$0.isEmpty }.joined(separator: " ")
-        return message.isEmpty ? fallback : message
+        let body = String(data: response.payload, encoding: .utf8)?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return (fallback + " Body: " + body).trimmingCharacters(in: .whitespaces)
     }
 
     private func extractResponseEtag(response: SmartyResponse?) -> String? {

--- a/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProSerializer.swift
+++ b/Sources/SmartyStreets/USAutocompletePro/USAutocompleteProSerializer.swift
@@ -34,6 +34,10 @@ public class USAutocompleteProSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:USAutocompleteProResult = try jsonDecoder.decode(USAutocompleteProResult.self, from: payload!)

--- a/Sources/SmartyStreets/USEnrichment/USEnrichmentClient.swift
+++ b/Sources/SmartyStreets/USEnrichment/USEnrichmentClient.swift
@@ -31,6 +31,7 @@ public class USEnrichmentClient: NSObject {
     public func sendPropertyPrincipalLookup(inputLookup: EnrichmentLookup, error: UnsafeMutablePointer<NSError?>) -> [PrincipalResult]? {
         let lookup = PropertyPrincipalEnrichmentLookup(lookup: inputLookup)
         _ = sendEnrichment(lookup: lookup, error: error)
+        inputLookup.setResponseEtag(etag: lookup.getResponseEtag())
         return lookup.results
     }
 
@@ -43,6 +44,7 @@ public class USEnrichmentClient: NSObject {
     public func sendGeoReferenceLookup(inputLookup: EnrichmentLookup, error: UnsafeMutablePointer<NSError?>) -> [GeoReferenceResult]? {
         let lookup = GeoReferenceEnrichmentLookup(lookup: inputLookup)
         _ = sendEnrichment(lookup: lookup, error: error)
+        inputLookup.setResponseEtag(etag: lookup.getResponseEtag())
         return lookup.results
     }
 
@@ -55,6 +57,7 @@ public class USEnrichmentClient: NSObject {
     public func sendSecondaryLookup(inputLookup: EnrichmentLookup, error: UnsafeMutablePointer<NSError?>) -> [SecondaryResult]? {
         let lookup = SecondaryEnrichmentLookup(lookup: inputLookup)
         _ = sendEnrichment(lookup: lookup, error: error)
+        inputLookup.setResponseEtag(etag: lookup.getResponseEtag())
         return lookup.results
     }
 
@@ -67,6 +70,7 @@ public class USEnrichmentClient: NSObject {
     public func sendSecondaryCountLookup(inputLookup: EnrichmentLookup, error: UnsafeMutablePointer<NSError?>) -> [SecondaryCountResult]? {
         let lookup = SecondaryCountEnrichmentLookup(lookup: inputLookup)
         _ = sendEnrichment(lookup: lookup, error: error)
+        inputLookup.setResponseEtag(etag: lookup.getResponseEtag())
         return lookup.results
     }
 
@@ -79,6 +83,7 @@ public class USEnrichmentClient: NSObject {
     public func sendBusinessLookup(inputLookup: EnrichmentLookup, error: UnsafeMutablePointer<NSError?>) -> [BusinessSummaryResult]? {
         let lookup = BusinessSummaryEnrichmentLookup(lookup: inputLookup)
         _ = sendEnrichment(lookup: lookup, error: error)
+        inputLookup.setResponseEtag(etag: lookup.getResponseEtag())
         return lookup.results
     }
 
@@ -129,14 +134,15 @@ public class USEnrichmentClient: NSObject {
     private func dispatch(request: SmartyRequest, lookup: EnrichmentLookupBase, serializer: SmartySerializer, error: UnsafeMutablePointer<NSError?>) -> Bool {
         let response = self.sender.sendRequest(request: request, error: &error.pointee)
 
-        // Capture the server-refreshed ETag even if a 304 surfaced as NSError (the underlying
-        // response is still delivered). The NotModifiedInfo NSError already carries this in
-        // userInfo, but mirroring it on the lookup keeps both paths symmetric.
         if let response = response, let etag = responseEtag(from: response.headers) {
             lookup.setResponseEtag(etag: etag)
         }
 
         if error.pointee != nil { return false }
+
+        if let response = response, response.statusCode == 304 {
+            return true
+        }
 
         if let response = response {
             lookup.deserializeAndSetResults(serializer: serializer, payload: response.payload, error: error)

--- a/Sources/SmartyStreets/USReverseGeo/USReverseGeoSerializer.swift
+++ b/Sources/SmartyStreets/USReverseGeo/USReverseGeoSerializer.swift
@@ -32,6 +32,10 @@ class USReverseGeoSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:USReverseGeoResponse = try jsonDecoder.decode(USReverseGeoResponse.self, from: payload!)

--- a/Sources/SmartyStreets/USStreet/USStreetSerializer.swift
+++ b/Sources/SmartyStreets/USStreet/USStreetSerializer.swift
@@ -33,6 +33,10 @@ public class USStreetSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:[USStreetCandidate] = try jsonDecoder.decode([USStreetCandidate].self, from: payload!)

--- a/Sources/SmartyStreets/USZipCode/USZipCodeSerializer.swift
+++ b/Sources/SmartyStreets/USZipCode/USZipCodeSerializer.swift
@@ -32,6 +32,10 @@ public class USZipCodeSerializer: SmartySerializer {
             error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
             return nil
         }
+
+        if payload!.isEmpty {
+            return nil
+        }
         
         do {
             let result:[USZipCodeResult] = try jsonDecoder.decode([USZipCodeResult].self, from: payload!)

--- a/Tests/SmartyStreetsTests/SerializerTests.swift
+++ b/Tests/SmartyStreetsTests/SerializerTests.swift
@@ -93,9 +93,16 @@ class SerializerTests: XCTestCase {
     
     func testDeserializeResult() {
         let result:[USZipCodeResult] = (serializer.Deserialize(payload: jsonData.data(using: .utf8), error: &self.error) as? [USZipCodeResult])!
-        
+
         XCTAssertNotNil(result[0])
         XCTAssertNotNil(result[1])
     }
-    
+
+    func testDeserializeEmptyPayloadReturnsNilWithoutError() {
+        let result = serializer.Deserialize(payload: Data(), error: &self.error)
+
+        XCTAssertNil(result)
+        XCTAssertNil(self.error)
+    }
+
 }

--- a/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
+++ b/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
@@ -47,7 +47,7 @@ class StatusCodeSenderTests: XCTestCase {
     // MARK: - Fallback message (payload has no parseable error)
 
     func test400ResponseUsesFallbackMessage() {
-        assertFallbackMessage(statusCode: 400, expectedFallback: "Bad Request (Malformed Payload): A GET request lacked a street field or the request body of a POST request contained malformed JSON.")
+        assertFallbackMessage(statusCode: 400, expectedFallback: "Bad Request (Malformed Payload): A GET request lacked a required field or the request body of a POST request contained malformed JSON.")
     }
 
     func test401ResponseUsesFallbackMessage() {
@@ -64,6 +64,34 @@ class StatusCodeSenderTests: XCTestCase {
 
     func test422ResponseUsesFallbackMessage() {
         assertFallbackMessage(statusCode: 422, expectedFallback: "GET request lacked required fields.")
+    }
+
+    func test403ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 403, expectedFallback: "Forbidden: The request contained valid data and was understood by the server, but the server is refusing action.")
+    }
+
+    func test408ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 408, expectedFallback: "Request timeout error.")
+    }
+
+    func test500ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 500, expectedFallback: "Internal Server Error.")
+    }
+
+    func test502ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 502, expectedFallback: "Bad Gateway error.")
+    }
+
+    func test503ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 503, expectedFallback: "Service Unavailable. Try again later.")
+    }
+
+    func test504ResponseUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 504, expectedFallback: "The upstream data provider did not respond in a timely fashion and the request failed. A serious, yet rare occurrence indeed.")
+    }
+
+    func testUnexpectedStatusCodeUsesFallbackMessage() {
+        assertFallbackMessage(statusCode: 418, expectedFallback: "The server returned an unexpected HTTP status code: 418")
     }
 
     // MARK: - Parsed message (payload carries an error message)
@@ -88,16 +116,72 @@ class StatusCodeSenderTests: XCTestCase {
         assertParsedMessage(statusCode: 422)
     }
 
+    func test403ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 403)
+    }
+
+    func test408ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 408)
+    }
+
+    func test500ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 500)
+    }
+
+    func test502ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 502)
+    }
+
+    func test503ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 503)
+    }
+
+    func test504ResponseUsesParsedMessage() {
+        assertParsedMessage(statusCode: 504)
+    }
+
+    func testParsedMessageDoesNotRequireIdField() {
+        let mockStatusCodeSender = MockStatusCodeSender(statusCode: 401, payload: """
+            {"errors":[{"message": "no id supplied"}]}
+            """)
+        let sender = StatusCodeSender(inner: mockStatusCodeSender)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(401, self.error.code)
+        XCTAssertEqual("no id supplied", self.error.localizedDescription)
+    }
+
     func test429ResponseThrowsTooManyRequestsError() {
         assertSendWithStatusCode(statusCode: 429)
     }
-    
+
     func test429ResponseMessage() {
         assertSendWithStatusCodeAndMessage(statusCode: 429, message:
                                             """
                                            {"errors":[{"id": 1234, "message": "Why so aggressive?"}]}
                                            """
         )
+    }
+
+    func test429ResponseUsesFallbackMessage() {
+        let mockStatusCodeSender = MockStatusCodeSender(statusCode: 429)
+        let sender = StatusCodeSender(inner: mockStatusCodeSender)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(429, self.error.code)
+        XCTAssertEqual("Too Many Requests: The rate limit for your account has been exceeded.", self.error.localizedDescription)
+    }
+
+    func test304ResponseUsesStandardMessage() {
+        let inner = MockSender(statusCode: 304, payload: Data(), headers: [:])
+        let sender = StatusCodeSender(inner: inner)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(304, self.error.code)
+        XCTAssertEqual("Not Modified: The requested record has not been modified since the previous request with the Etag value.", self.error.localizedDescription)
     }
     
     func test500ResponseThrowsInternalServerError() {
@@ -181,8 +265,8 @@ class StatusCodeSenderTests: XCTestCase {
         let sender = StatusCodeSender(inner: mockStatusCodeSender)
         
         let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
-        
+
         XCTAssertEqual(statusCode, self.error.code)
-        XCTAssertEqual("Too Many Requests: Why so aggressive?", self.error.localizedDescription)
+        XCTAssertEqual("Why so aggressive?", self.error.localizedDescription)
     }
 }

--- a/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
+++ b/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
@@ -140,6 +140,36 @@ class StatusCodeSenderTests: XCTestCase {
         assertParsedMessage(statusCode: 504)
     }
 
+    func testFallbackAppendsUnparseableBody() {
+        let mockStatusCodeSender = MockStatusCodeSender(statusCode: 422, payload: "not json")
+        let sender = StatusCodeSender(inner: mockStatusCodeSender)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(422, self.error.code)
+        XCTAssertEqual("GET request lacked required fields. Body: not json", self.error.localizedDescription)
+    }
+
+    func testFallbackAppendsBodyWithoutMessages() {
+        let mockStatusCodeSender = MockStatusCodeSender(statusCode: 422, payload: "{\"errors\":[]}")
+        let sender = StatusCodeSender(inner: mockStatusCodeSender)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(422, self.error.code)
+        XCTAssertEqual("GET request lacked required fields. Body: {\"errors\":[]}", self.error.localizedDescription)
+    }
+
+    func testBlankBodyYieldsEmptyBodyLabel() {
+        let mockStatusCodeSender = MockStatusCodeSender(statusCode: 422, payload: "   ")
+        let sender = StatusCodeSender(inner: mockStatusCodeSender)
+
+        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+
+        XCTAssertEqual(422, self.error.code)
+        XCTAssertEqual("GET request lacked required fields. Body:", self.error.localizedDescription)
+    }
+
     func testParsedMessageDoesNotRequireIdField() {
         let mockStatusCodeSender = MockStatusCodeSender(statusCode: 401, payload: """
             {"errors":[{"message": "no id supplied"}]}
@@ -171,7 +201,7 @@ class StatusCodeSenderTests: XCTestCase {
         let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
 
         XCTAssertEqual(429, self.error.code)
-        XCTAssertEqual("Too Many Requests: The rate limit for your account has been exceeded.", self.error.localizedDescription)
+        XCTAssertEqual("Too Many Requests: The rate limit for your account has been exceeded. Body:", self.error.localizedDescription)
     }
 
     func test304ResponseUsesStandardMessage() {
@@ -243,7 +273,7 @@ class StatusCodeSenderTests: XCTestCase {
 
         XCTAssertNil(response, "status \(statusCode) should return a nil response")
         XCTAssertEqual(statusCode, self.error.code)
-        XCTAssertEqual(expectedFallback, self.error.localizedDescription)
+        XCTAssertEqual(expectedFallback + " Body:", self.error.localizedDescription)
     }
 
     func assertParsedMessage(statusCode:Int) {

--- a/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
+++ b/Tests/SmartyStreetsTests/StatusCodeSenderTests.swift
@@ -204,14 +204,16 @@ class StatusCodeSenderTests: XCTestCase {
         XCTAssertEqual("Too Many Requests: The rate limit for your account has been exceeded. Body:", self.error.localizedDescription)
     }
 
-    func test304ResponseUsesStandardMessage() {
-        let inner = MockSender(statusCode: 304, payload: Data(), headers: [:])
+    func test304IsNotAnError() {
+        self.error = nil
+        let inner = MockSender(statusCode: 304, payload: Data(), headers: ["Etag": "server-refreshed-etag"])
         let sender = StatusCodeSender(inner: inner)
 
-        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
+        let response = sender.sendRequest(request: SmartyRequest(), error: &self.error)
 
-        XCTAssertEqual(304, self.error.code)
-        XCTAssertEqual("Not Modified: The requested record has not been modified since the previous request with the Etag value.", self.error.localizedDescription)
+        XCTAssertNil(self.error)
+        XCTAssertEqual(304, response?.statusCode)
+        XCTAssertEqual("server-refreshed-etag", response?.headers["Etag"])
     }
     
     func test500ResponseThrowsInternalServerError() {
@@ -226,35 +228,6 @@ class StatusCodeSenderTests: XCTestCase {
         assertSendWithStatusCode(statusCode: 504)
     }
     
-    func testNotModifiedCarriesResponseEtagFromHeader() {
-        let inner = MockSender(statusCode: 304, payload: Data(), headers: ["Etag": "server-refreshed-etag"])
-        let sender = StatusCodeSender(inner: inner)
-
-        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
-
-        XCTAssertEqual(304, self.error.code)
-        XCTAssertEqual("server-refreshed-etag", self.error.userInfo[SmartyErrors.ResponseEtagKey] as? String)
-    }
-
-    func testNotModifiedResponseEtagHeaderCaseInsensitive() {
-        let inner = MockSender(statusCode: 304, payload: Data(), headers: ["ETag": "case-insensitive-etag"])
-        let sender = StatusCodeSender(inner: inner)
-
-        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
-
-        XCTAssertEqual(304, self.error.code)
-        XCTAssertEqual("case-insensitive-etag", self.error.userInfo[SmartyErrors.ResponseEtagKey] as? String)
-    }
-
-    func testNotModifiedNoHeaderLeavesResponseEtagAbsent() {
-        let inner = MockSender(statusCode: 304, payload: Data(), headers: [:])
-        let sender = StatusCodeSender(inner: inner)
-
-        let _ = sender.sendRequest(request: SmartyRequest(), error: &self.error)
-
-        XCTAssertEqual(304, self.error.code)
-        XCTAssertNil(self.error.userInfo[SmartyErrors.ResponseEtagKey])
-    }
 
     func assertSendWithStatusCode(statusCode:Int) {
         let mockStatusCodeSender = MockStatusCodeSender(statusCode: statusCode)

--- a/Tests/SmartyStreetsTests/USEnrichmentTests/USEnrichmentClientTests.swift
+++ b/Tests/SmartyStreetsTests/USEnrichmentTests/USEnrichmentClientTests.swift
@@ -304,17 +304,17 @@ class USEnrichmentClientTests: XCTestCase {
 
     // MARK: - 304 Not Modified via full StatusCodeSender
 
-    func testBusinessDetailOn304SurfacesErrorAndCapturesResponseEtag() {
+    func testBusinessDetailOn304IsSuccessWithRefreshedEtag() {
         // Wrap a raw 304 MockSender in StatusCodeSender so dispatch() sees both a populated
         // response and an NSError — the same shape that hits the client in production.
-        let inner = MockSender(statusCode: 304, payload: "[]".data(using: .utf8)!, headers: ["Etag": "server-refreshed"])
+        let inner = MockSender(statusCode: 304, payload: Data(), headers: ["Etag": "server-refreshed"])
         let client = USEnrichmentClient(sender: StatusCodeSender(inner: inner))
         let lookup = BusinessDetailEnrichmentLookup(businessId: "ABC")
+        lookup.setRequestEtag(etag: "old-etag")
 
         _ = client.sendBusinessDetailLookup(lookup: lookup, error: &self.error)
 
-        XCTAssertEqual(SmartyErrors.SSErrors.NotModifiedInfo.rawValue, self.error.code)
-        XCTAssertEqual("server-refreshed", self.error.userInfo[SmartyErrors.ResponseEtagKey] as? String)
+        XCTAssertNil(self.error)
         XCTAssertEqual("server-refreshed", lookup.getResponseEtag())
     }
 
@@ -356,6 +356,17 @@ class USEnrichmentClientTests: XCTestCase {
         XCTAssertNotNil(self.error)
         XCTAssertEqual(SmartyErrors.SSErrors.FieldNotSetError.rawValue, self.error.code)
         XCTAssertNil(sender.request)
+    }
+
+    func testInputLookupOverloadPropagatesResponseEtag() {
+        let (client, _) = capturingClient(responseHeaders: ["Etag": "srv-etag"])
+        let lookup = EnrichmentLookup()
+        lookup.setSmartyKey(smarty_key: "1")
+
+        _ = client.sendBusinessLookup(inputLookup: lookup, error: &self.error)
+
+        XCTAssertNil(self.error)
+        XCTAssertEqual("srv-etag", lookup.getResponseEtag())
     }
 }
 

--- a/samples/Sources/swiftExamples/USEnrichmentEtagExample.swift
+++ b/samples/Sources/swiftExamples/USEnrichmentEtagExample.swift
@@ -1,0 +1,38 @@
+import Foundation
+import SmartyStreets
+
+class USEnrichmentEtagExample {
+    var error: NSError! = nil
+
+    func run() throws -> String {
+        let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
+        let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
+        let client = ClientBuilder.withBasicAuth(authId: authId, authToken: authToken).buildUsEnrichmentApiClient()
+
+        let smartyKey = "1962995076"
+        var output = ""
+
+        let first = EnrichmentLookup()
+        first.setSmartyKey(smarty_key: smartyKey)
+        let firstResults = client.sendBusinessLookup(inputLookup: first, error: &error)
+        if let error = error {
+            return "First call failed: \(error.localizedDescription)"
+        }
+        output += "First call: \((firstResults ?? []).count) result(s), Etag=\(first.getResponseEtag())\n"
+
+        let second = EnrichmentLookup()
+        second.setSmartyKey(smarty_key: smartyKey)
+        second.setRequestEtag(etag: first.getResponseEtag())
+        let secondResults = client.sendBusinessLookup(inputLookup: second, error: &error)
+        if let error = error {
+            return output + "Second call failed: \(error.localizedDescription)"
+        }
+        if (secondResults ?? []).isEmpty {
+            output += "Second call: not modified, Etag=\(second.getResponseEtag())\n"
+        } else {
+            output += "Second call: modified, \((secondResults ?? []).count) result(s), Etag=\(second.getResponseEtag())\n"
+        }
+
+        return output
+    }
+}

--- a/samples/Sources/swiftExamples/main.swift
+++ b/samples/Sources/swiftExamples/main.swift
@@ -15,3 +15,4 @@ import Foundation
 // print(USReverseGeoExample().run())
 // print(USStreetIanaTimeZoneExample().run())
 // print(try USEnrichmentExample().run())
+// print(try USEnrichmentEtagExample().run())


### PR DESCRIPTION
## Summary

Implements the standard error message scheme shared across all Smarty SDKs: every HTTP error status now surfaces the message from the API's JSON error body (`{"errors":[{"message":"..."}]}`) when one is present, and falls back to the standard per-status message list otherwise (304, 400, 401, 402, 403, 408, 413, 422, 429, 500, 502, 503, 504, plus an "unexpected status code" default).

## In this SDK

- Added 403/408/502 and unexpected-status handling (these previously returned a nil response with no error set).
- 429/5xx now extract the API message; the response-error structs tolerate bodies without an `id` field (matching real API 4xx bodies).

## Validation

- Unit tests cover every handled status: API message preferred, exact standard fallback on empty/malformed/unusable bodies, unknown status codes, and unchanged 304/ETag behavior.
- Verified against the live API with real credentials: 400 (missing street), 401 (bad credentials), 404 (unexpected-status path), and 422 (out-of-range latitude) each surfaced the server's own message through this SDK's full client chain.

## Related PRs (same change in every SDK)

- [smartystreets-java-sdk](https://github.com/smartystreets/smartystreets-java-sdk/pull/87)
- [smartystreets-go-sdk](https://github.com/smartystreets/smartystreets-go-sdk/pull/60)
- [smarty-rust-sdk](https://github.com/smarty/smarty-rust-sdk/pull/57)
- [smartystreets-python-sdk](https://github.com/smartystreets/smartystreets-python-sdk/pull/93)
- [smartystreets-ruby-sdk](https://github.com/smartystreets/smartystreets-ruby-sdk/pull/85)
- [smartystreets-php-sdk](https://github.com/smartystreets/smartystreets-php-sdk/pull/89)
- [smartystreets-javascript-sdk](https://github.com/smarty/smartystreets-javascript-sdk/pull/146)
- [smartystreets-dotnet-sdk](https://github.com/smartystreets/smartystreets-dotnet-sdk/pull/77)
- [smartystreets-ios-sdk](https://github.com/smartystreets/smartystreets-ios-sdk/pull/67)
