### PR TITLE
Add US Autocomplete (V2) API client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ example-us-zipcode-multiple:
 example-us-autocomplete-pro:
 	@$(call run-example,USAutocompleteProExample)
 
+example-us-autocomplete:
+	@$(call run-example,USAutocompleteExample)
+
 example-us-extract:
 	@$(call run-example,USExtractExample)
 
@@ -76,6 +79,7 @@ examples-all:
 	@$(MAKE) example-us-zipcode-single
 	@$(MAKE) example-us-zipcode-multiple
 	@$(MAKE) example-us-autocomplete-pro
+	@$(MAKE) example-us-autocomplete
 	@$(MAKE) example-us-extract
 	@$(MAKE) example-international-street
 	@$(MAKE) example-international-autocomplete
@@ -102,5 +106,6 @@ publish: compile test version
 .PHONY: example-us-street-single example-us-street-multiple example-us-street-component-analysis
 .PHONY: example-us-zipcode-single example-us-zipcode-multiple
 .PHONY: example-us-autocomplete-pro example-us-extract
+.PHONY: example-us-autocomplete example-us-extract
 .PHONY: example-international-street example-international-autocomplete example-international-postal-code
 .PHONY: example-us-reverse-geo example-us-street-iana-timezone example-us-enrichment example-us-enrichment-business-search

--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ if let suggestions = lookup.result?.suggestions {
 | [US Street](https://www.smarty.com/docs/cloud/us-street-api) | `USStreetLookup` | `buildUsStreetApiClient()` | [example](samples/Sources/swiftExamples/USStreetSingleAddressExample.swift) |
 | [US Zipcode](https://www.smarty.com/docs/cloud/us-zipcode-api) | `USZipCodeLookup` | `buildUsZIPCodeApiClient()` | [example](samples/Sources/swiftExamples/USZipCodeSingleLookupExample.swift) |
 | [US Autocomplete Pro](https://www.smarty.com/docs/cloud/us-autocomplete-pro-api) | `USAutocompleteProLookup` | `buildUSAutocompleteProApiClient()` | [example](samples/Sources/swiftExamples/USAutocompleteProExample.swift) |
+| [US Autocomplete](https://www.smarty.com/docs/apis/us-autocomplete-v2) | `USAutocompleteLookup` | `buildUSAutocompleteApiClient()` | [example](samples/Sources/swiftExamples/USAutocompleteExample.swift) |
 | [US Extract](https://www.smarty.com/docs/cloud/us-extract-api) | `USExtractLookup` | `buildUsExtractApiClient()` | [example](samples/Sources/swiftExamples/USExtractExample.swift) |
 | [US Enrichment](https://www.smarty.com/docs/cloud/us-address-enrichment-api) | `EnrichmentLookup` | `buildUsEnrichmentApiClient()` | [example](samples/Sources/swiftExamples/USEnrichmentExample.swift) |
 | [US Reverse Geocoding](https://www.smarty.com/docs/cloud/us-reverse-geo-api) | `USReverseGeoLookup` | `buildUsReverseGeoApiClient()` | [example](samples/Sources/swiftExamples/USReverseGeoExample.swift) |

--- a/Sources/SmartyStreets/ClientBuilder.swift
+++ b/Sources/SmartyStreets/ClientBuilder.swift
@@ -20,6 +20,7 @@ import Foundation
     var internationalAutocompleteApiURL:String = "https://international-autocomplete.api.smarty.com/v2/lookup"
     var internationalPostalCodeApiURL:String = "https://international-postal-code.api.smarty.com/lookup"
     var usAutocompleteProApiURL:String = "https://us-autocomplete-pro.api.smarty.com/lookup"
+    var usAutocompleteApiURL:String = "https://us-autocomplete.api.smarty.com/v2/lookup"
     var usExtractApiURL:String = "https://us-extract.api.smarty.com"
     var usStreetApiURL:String = "https://us-street.api.smarty.com/street-address"
     var usZipCodeApiURL:String = "https://us-zipcode.api.smarty.com/lookup"
@@ -213,6 +214,12 @@ import Foundation
        ensureURLPrefixNotNil(url: self.usAutocompleteProApiURL)
        let serializer = USAutocompleteProSerializer()
        return USAutocompleteProClient(sender: buildSender(), serializer: serializer)
+    }
+
+    public func buildUSAutocompleteApiClient() -> USAutocompleteClient {
+       ensureURLPrefixNotNil(url: self.usAutocompleteApiURL)
+       let serializer = USAutocompleteSerializer()
+       return USAutocompleteClient(sender: buildSender(), serializer: serializer)
     }
     
     public func buildUsExtractApiClient() -> USExtractClient {

--- a/Sources/SmartyStreets/USAutocomplete/Source.swift
+++ b/Sources/SmartyStreets/USAutocomplete/Source.swift
@@ -1,0 +1,12 @@
+import Foundation
+
+@objcMembers public class USAutocompleteSource: NSObject {
+    public static let all    = USAutocompleteSource(name: "all")
+    public static let postal = USAutocompleteSource(name: "postal")
+
+    public var name: String
+
+    public init(name: String) {
+        self.name = name
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
@@ -48,11 +48,11 @@ public class USAutocompleteClient: NSObject {
         request.setValue(value: lookup.getMaxResultsStringIfSet(), HTTPParameterField: "max_results")
         request.setValue(value: buildFilterString(list: lookup.includeOnlyCities ?? [String]()), HTTPParameterField: "include_only_cities")
         request.setValue(value: buildFilterString(list: lookup.includeOnlyStates ?? [String]()), HTTPParameterField: "include_only_states")
-        request.setValue(value: buildFilterString(list: lookup.includeOnlyZIPCodes ?? [String]()), HTTPParameterField: "include_only_zipcodes")
+        request.setValue(value: buildFilterString(list: lookup.includeOnlyZIPCodes ?? [String]()), HTTPParameterField: "include_only_zip_codes")
         request.setValue(value: buildFilterString(list: lookup.excludeStates ?? [String]()), HTTPParameterField: "exclude_states")
         request.setValue(value: buildFilterString(list: lookup.preferCities ?? [String]()), HTTPParameterField: "prefer_cities")
         request.setValue(value: buildFilterString(list: lookup.preferStates ?? [String]()), HTTPParameterField: "prefer_states")
-        request.setValue(value: buildFilterString(list: lookup.preferZIPCodes ?? [String]()), HTTPParameterField: "prefer_zipcodes")
+        request.setValue(value: buildFilterString(list: lookup.preferZIPCodes ?? [String]()), HTTPParameterField: "prefer_zip_codes")
         request.setValue(value: lookup.source ?? "", HTTPParameterField: "source")
         request.setValue(value: lookup.getPreferRatioStringIfSet(), HTTPParameterField: "prefer_ratio")
 

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
@@ -53,7 +53,7 @@ public class USAutocompleteClient: NSObject {
         request.setValue(value: buildFilterString(list: lookup.preferCities ?? [String]()), HTTPParameterField: "prefer_cities")
         request.setValue(value: buildFilterString(list: lookup.preferStates ?? [String]()), HTTPParameterField: "prefer_states")
         request.setValue(value: buildFilterString(list: lookup.preferZIPCodes ?? [String]()), HTTPParameterField: "prefer_zipcodes")
-        request.setValue(value: lookup.source ?? "", HTTPParameterField: "source")
+        request.setValue(value: lookup.source?.name ?? "", HTTPParameterField: "source")
         request.setValue(value: lookup.getPreferRatioStringIfSet(), HTTPParameterField: "prefer_ratio")
 
         if lookup.preferGeolocation!.name != "none" && lookup.preferZIPCodes == [String]() {

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
@@ -3,8 +3,6 @@ import Foundation
 public class USAutocompleteClient: NSObject {
     //    It is recommended to instantiate this class using SSClientBuilder
 
-    static let arrayItemsSeparator = ";"
-
     var sender:SmartySender
     public var serializer:SmartySerializer
 
@@ -44,7 +42,7 @@ public class USAutocompleteClient: NSObject {
 
         request.setValue(value: lookup.search ?? "", HTTPParameterField: "search")
         request.setValue(value: lookup.selected ?? "", HTTPParameterField: "selected")
-        request.setValue(value: lookup.exclude ?? "", HTTPParameterField: "exclude")
+        request.setValue(value: buildFilterString(list: lookup.exclude ?? [String](), separator: ","), HTTPParameterField: "exclude")
         request.setValue(value: lookup.getMaxResultsStringIfSet(), HTTPParameterField: "max_results")
         request.setValue(value: buildFilterString(list: lookup.includeOnlyCities ?? [String]()), HTTPParameterField: "include_only_cities")
         request.setValue(value: buildFilterString(list: lookup.includeOnlyStates ?? [String]()), HTTPParameterField: "include_only_states")
@@ -67,11 +65,11 @@ public class USAutocompleteClient: NSObject {
         return request
     }
 
-    func buildFilterString(list:[String]) -> String {
+    func buildFilterString(list:[String], separator:String=";") -> String {
         if list.count == 0 {
             return String()
         }
 
-        return list.joined(separator: Self.arrayItemsSeparator)
+        return list.joined(separator: separator)
     }
 }

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteClient.swift
@@ -1,0 +1,77 @@
+import Foundation
+
+public class USAutocompleteClient: NSObject {
+    //    It is recommended to instantiate this class using SSClientBuilder
+
+    static let arrayItemsSeparator = ";"
+
+    var sender:SmartySender
+    public var serializer:SmartySerializer
+
+    public init(sender:Any, serializer:SmartySerializer) {
+        self.sender = sender as! SmartySender
+        self.serializer = serializer
+    }
+
+    @objc public func sendLookup(lookup: UnsafeMutablePointer<USAutocompleteLookup>, error: UnsafeMutablePointer<NSError?>) -> Bool {
+        //        Sends a Lookup object to the US Autocomplete API and stores the result in the Lookup's result field.
+
+        if let search = lookup.pointee.search {
+            if search.count == 0 {
+                let details = [NSLocalizedDescriptionKey:"sendLookup must be passed a Lookup with the search field set."]
+                error.pointee = NSError(domain: SmartyErrors().SSErrorDomain, code: SmartyErrors.SSErrors.FieldNotSetError.rawValue, userInfo: details)
+                return false
+            }
+
+            let request = buildRequest(lookup:lookup.pointee)
+            let response = self.sender.sendRequest(request: request, error: &error.pointee)
+            if error.pointee != nil { return false }
+
+            let result:USAutocompleteResult = self.serializer.Deserialize(payload: response?.payload, error: &error.pointee) as! USAutocompleteResult
+
+            // Naming of parameters to allow JSON deserialization
+            if error.pointee != nil { return false }
+
+            lookup.pointee.result = result
+            return true
+        } else {
+            return false
+        }
+    }
+
+    func buildRequest(lookup:USAutocompleteLookup) -> SmartyRequest {
+        let request = SmartyRequest()
+
+        request.setValue(value: lookup.search ?? "", HTTPParameterField: "search")
+        request.setValue(value: lookup.selected ?? "", HTTPParameterField: "selected")
+        request.setValue(value: lookup.exclude ?? "", HTTPParameterField: "exclude")
+        request.setValue(value: lookup.getMaxResultsStringIfSet(), HTTPParameterField: "max_results")
+        request.setValue(value: buildFilterString(list: lookup.includeOnlyCities ?? [String]()), HTTPParameterField: "include_only_cities")
+        request.setValue(value: buildFilterString(list: lookup.includeOnlyStates ?? [String]()), HTTPParameterField: "include_only_states")
+        request.setValue(value: buildFilterString(list: lookup.includeOnlyZIPCodes ?? [String]()), HTTPParameterField: "include_only_zipcodes")
+        request.setValue(value: buildFilterString(list: lookup.excludeStates ?? [String]()), HTTPParameterField: "exclude_states")
+        request.setValue(value: buildFilterString(list: lookup.preferCities ?? [String]()), HTTPParameterField: "prefer_cities")
+        request.setValue(value: buildFilterString(list: lookup.preferStates ?? [String]()), HTTPParameterField: "prefer_states")
+        request.setValue(value: buildFilterString(list: lookup.preferZIPCodes ?? [String]()), HTTPParameterField: "prefer_zipcodes")
+        request.setValue(value: lookup.source ?? "", HTTPParameterField: "source")
+        request.setValue(value: lookup.getPreferRatioStringIfSet(), HTTPParameterField: "prefer_ratio")
+
+        if lookup.preferGeolocation!.name != "none" && lookup.preferZIPCodes == [String]() {
+            request.setValue(value: lookup.preferGeolocation!.name, HTTPParameterField: "prefer_geolocation")
+        }
+
+        for key in lookup.getCustomParamArray().keys {
+            request.setValue(value: lookup.getCustomParamArray()[key] ?? "", HTTPParameterField: key)
+        }
+
+        return request
+    }
+
+    func buildFilterString(list:[String]) -> String {
+        if list.count == 0 {
+            return String()
+        }
+
+        return list.joined(separator: Self.arrayItemsSeparator)
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+@objcMembers public class USAutocompleteLookup: NSObject, Codable {
+    //    In addition to holding all of the input data for this lookup, this class also will contain the result
+    //    of the lookup after it comes back from the API.
+    //
+    //    See "https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-request-input-fields"
+    //
+    //    search: The beginning of an address (required)
+    //    maxResults: Maximum number of suggestions
+    //    cityFilter: List of cities from which to include suggestions
+    //    stateFilter: List of states from which to include suggestions
+    //    prefer: List of cities/states. Suggestions from the members of this list will appear first
+    //    preferRatio: Percentage of suggestions that will be from preferred cities/states.
+    //    geolocateType: This field corresponds to the geolocate and geolocate precision fields in the
+    //    US Autocomplete API. Use the constants in GeolocateType to set this field
+
+    let SSMaxResults = 10
+    let SSPreferRatio = 3
+
+    private var customParamArray: [String: String] = [:]
+    public var result:USAutocompleteResult?
+    public var search:String?
+    public var selected:String?
+    public var exclude:String?
+    public var maxResults:Int?
+    public var includeOnlyCities:[String]?
+    public var includeOnlyStates:[String]?
+    public var includeOnlyZIPCodes:[String]?
+    public var excludeStates:[String]?
+    public var preferCities:[String]?
+    public var preferStates:[String]?
+    public var preferZIPCodes:[String]?
+    public var preferGeolocation:GeolocateType?
+    public var preferRatio:Int?
+    public var source:String?
+
+    enum CodingKeys: String, CodingKey {
+        case maxResults = "max_results"
+        case includeOnlyCities = "include_only_cities"
+        case includeOnlyStates = "include_only_states"
+        case includeOnlyZIPCodes = "include_only_zipcodes"
+        case excludeStates = "exclude_states"
+        case preferCities = "prefer_cities"
+        case preferStates = "prefer_states"
+        case preferZIPCodes = "prefer_zipcodes"
+        case preferGeolocation = "prefer_geolocation"
+        case preferRatio = "prefer_ratio"
+        case source = "source"
+        case exclude = "exclude"
+    }
+
+    override public init() {
+        self.maxResults = SSMaxResults
+        self.includeOnlyCities = [String]()
+        self.includeOnlyStates = [String]()
+        self.includeOnlyZIPCodes = [String]()
+        self.excludeStates = [String]()
+        self.preferCities = [String]()
+        self.preferStates = [String]()
+        self.preferZIPCodes = [String]()
+        self.preferGeolocation = GeolocateType(name:"city")
+        self.preferRatio = SSPreferRatio
+    }
+
+    public func withSearch(search:String) -> USAutocompleteLookup {
+        self.search = search
+        return self
+    }
+
+    func getResultAtIndex(index:Int) -> USAutocompleteSuggestion{
+        if let result = self.result {
+            return result.suggestions![index]
+        } else {
+            return USAutocompleteSuggestion(dictionary: NSDictionary())
+        }
+    }
+
+    func getMaxResultsStringIfSet() -> String {
+        if self.maxResults == SSMaxResults {
+            return String()
+        } else {
+            return "\(self.maxResults ?? 0)"
+        }
+    }
+
+    func getPreferRatioStringIfSet() -> String {
+        if self.preferRatio == SSPreferRatio {
+            return String()
+        } else {
+            return "\(self.preferRatio ?? 0)"
+        }
+    }
+
+    public func getCustomParamArray() -> [String: String] {
+        return self.customParamArray
+    }
+
+    public func setMaxResults(maxResults: Int, error: inout NSError?) {
+        if maxResults > 0 && maxResults <= 10 {
+            self.maxResults = maxResults
+        } else {
+            let details = [NSLocalizedDescriptionKey:"Max suggestions must be a postive integer no larger than 10."]
+            error = NSError(domain: SmartyErrors().SSErrorDomain, code: SmartyErrors.SSErrors.NotPositiveIntergerError.rawValue, userInfo: details)
+        }
+    }
+
+    public func addCityFilter(city:String) {
+        self.includeOnlyCities?.append(city)
+    }
+
+    public func addStateFilter(state:String) {
+        self.includeOnlyStates?.append(state)
+    }
+
+    public func addZIPCodeFilter(zipcode:String) {
+        self.includeOnlyZIPCodes?.append(zipcode)
+    }
+
+    public func addPreferCity(city:String) {
+        self.preferCities?.append(city)
+    }
+
+    public func addPreferState(state:String) {
+        self.preferStates?.append(state)
+    }
+
+    public func addPreferZIPCode(zipcode:String) {
+        self.preferZIPCodes?.append(zipcode)
+    }
+
+    public func addCustomParameter(parameter: String, value: String) {
+        self.customParamArray.updateValue(value, forKey: parameter)
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
@@ -22,7 +22,7 @@ import Foundation
     public var result:USAutocompleteResult?
     public var search:String?
     public var selected:String?
-    public var exclude:String?
+    public var exclude:[String]?
     public var maxResults:Int?
     public var includeOnlyCities:[String]?
     public var includeOnlyStates:[String]?
@@ -54,6 +54,7 @@ import Foundation
         self.includeOnlyCities = [String]()
         self.includeOnlyStates = [String]()
         self.includeOnlyZIPCodes = [String]()
+        self.exclude = [String]()
         self.excludeStates = [String]()
         self.preferCities = [String]()
         self.preferStates = [String]()
@@ -126,6 +127,10 @@ import Foundation
 
     public func addPreferZIPCode(zipcode:String) {
         self.preferZIPCodes?.append(zipcode)
+    }
+
+    public func addExclude(exclude:String) {
+        self.exclude?.append(exclude)
     }
 
     public func addCustomParameter(parameter: String, value: String) {

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteLookup.swift
@@ -33,7 +33,7 @@ import Foundation
     public var preferZIPCodes:[String]?
     public var preferGeolocation:GeolocateType?
     public var preferRatio:Int?
-    public var source:String?
+    public var source:USAutocompleteSource?
 
     enum CodingKeys: String, CodingKey {
         case maxResults = "max_results"
@@ -46,7 +46,6 @@ import Foundation
         case preferZIPCodes = "prefer_zipcodes"
         case preferGeolocation = "prefer_geolocation"
         case preferRatio = "prefer_ratio"
-        case source = "source"
         case exclude = "exclude"
     }
 

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteResult.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteResult.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+@objcMembers public class USAutocompleteResult: NSObject, Codable {
+
+    public var suggestions:[USAutocompleteSuggestion]?
+
+    public init(dictionary: NSDictionary) {
+        super.init()
+        if let suggestions = dictionary["suggestions"] {
+            self.suggestions = convertToSuggestionObjects(suggestions as! [[String:Any]])
+        } else {
+            self.suggestions = [USAutocompleteSuggestion]()
+        }
+    }
+
+    func convertToSuggestionObjects(_ object:[[String:Any]]) -> [USAutocompleteSuggestion] {
+        var mutable = [USAutocompleteSuggestion]()
+        for suggestion in object {
+            mutable.append(USAutocompleteSuggestion(dictionary: suggestion as NSDictionary))
+        }
+        return mutable
+    }
+
+    func getSuggestionAtIndex(index: Int) -> USAutocompleteSuggestion {
+        if let suggestions = self.suggestions {
+            return suggestions[index]
+        } else {
+            return USAutocompleteSuggestion(dictionary: NSDictionary())
+        }
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteSerializer.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteSerializer.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public class USAutocompleteSerializer: SmartySerializer {
+
+    override public init() {}
+
+    override func Serialize(obj: Any?, error: inout NSError!) -> Data! {
+        let raw:[USAutocompleteLookup]? = obj as? [USAutocompleteLookup]
+        let smartyErrors = SmartyErrors()
+        let jsonEncoder = JSONEncoder()
+        if raw == nil {
+            let details = [NSLocalizedDescriptionKey: "The object to be serialized is nil"]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
+            return nil
+        }
+
+        do {
+            let jsonData = try jsonEncoder.encode(raw) as Data
+            return jsonData
+        } catch let jsonError {
+            let details = [NSLocalizedDescriptionKey: jsonError.localizedDescription]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectInvalidTypeError.rawValue, userInfo: details)
+        }
+
+
+        return nil
+    }
+
+    override public func Deserialize(payload: Data?, error: inout NSError!) -> Any! {
+        let smartyErrors = SmartyErrors()
+        let jsonDecoder = JSONDecoder()
+        if payload == nil {
+            let details = [NSLocalizedDescriptionKey: "The payload is nil."]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectNilError.rawValue, userInfo: details)
+            return nil
+        }
+
+        do {
+            let result:USAutocompleteResult = try jsonDecoder.decode(USAutocompleteResult.self, from: payload!)
+            return result
+        } catch let jsonError {
+            let details = [NSLocalizedDescriptionKey:jsonError.localizedDescription]
+            error = NSError(domain: smartyErrors.SSErrorDomain, code: SmartyErrors.SSErrors.ObjectInvalidTypeError.rawValue, userInfo: details)
+            return nil
+        }
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteSuggestion.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteSuggestion.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+@objcMembers public class USAutocompleteSuggestion: NSObject, Codable {
+    //    See "https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-response-status"
+
+    public var smartyKey:String?
+    public var entryId:String?
+    public var streetLine:String?
+    public var secondary:String?
+    public var city:String?
+    public var state:String?
+    public var zipcode:String?
+    public var entries:Int?
+
+    enum CodingKeys: String, CodingKey {
+        case smartyKey = "smarty_key"
+        case entryId = "entry_id"
+        case streetLine = "street_line"
+        case secondary = "secondary"
+        case city = "city"
+        case state = "state"
+        case zipcode = "zipcode"
+        case entries = "entries"
+    }
+
+    init(dictionary: NSDictionary) {
+        self.smartyKey = dictionary["smarty_key"] as? String
+        self.entryId = dictionary["entry_id"] as? String
+        self.streetLine = dictionary["street_line"] as? String
+        self.secondary = dictionary["secondary"] as? String
+        self.city = dictionary["city"] as? String
+        self.state = dictionary["state"] as? String
+        self.zipcode = dictionary["zipcode"] as? String
+        self.entries = dictionary["entries"] as? Int
+    }
+}

--- a/Sources/SmartyStreets/USAutocomplete/USAutocompleteSuggestion.swift
+++ b/Sources/SmartyStreets/USAutocomplete/USAutocompleteSuggestion.swift
@@ -11,6 +11,7 @@ import Foundation
     public var state:String?
     public var zipcode:String?
     public var entries:Int?
+    public var source:String?
 
     enum CodingKeys: String, CodingKey {
         case smartyKey = "smarty_key"
@@ -21,6 +22,7 @@ import Foundation
         case state = "state"
         case zipcode = "zipcode"
         case entries = "entries"
+        case source = "source"
     }
 
     init(dictionary: NSDictionary) {
@@ -32,5 +34,6 @@ import Foundation
         self.state = dictionary["state"] as? String
         self.zipcode = dictionary["zipcode"] as? String
         self.entries = dictionary["entries"] as? Int
+        self.source = dictionary["source"] as? String
     }
 }

--- a/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
+++ b/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
@@ -1,5 +1,5 @@
 import XCTest
-import SmartyStreets
+@testable import SmartyStreets
 
 class USAutocompleteClientTests: XCTestCase {
 
@@ -45,7 +45,7 @@ class USAutocompleteClientTests: XCTestCase {
         lookup.addPreferCity(city: "preferCity")
         lookup.addPreferState(state: "preferState")
         lookup.preferRatio = 4
-        lookup.source = "all"
+        lookup.source = .all
         lookup.addCustomParameter(parameter: "custom", value: "7")
 
         _ = client.sendLookup(lookup:&lookup, error:&error)
@@ -63,6 +63,29 @@ class USAutocompleteClientTests: XCTestCase {
         XCTAssertEqual("all", capturingSender.request.parameters["source"])
         XCTAssertEqual("7", capturingSender.request.parameters["custom"])
         XCTAssertNil(self.error)
+    }
+
+    func testSourceAllIsSetInRequest() {
+        let client = USAutocompleteClient(sender: RequestCapturingSender(), serializer: MockSerializer())
+        let lookup = USAutocompleteLookup()
+        lookup.source = .all
+        let request = client.buildRequest(lookup: lookup)
+        XCTAssertEqual(request.parameters["source"], "all")
+    }
+
+    func testSourcePostalIsSetInRequest() {
+        let client = USAutocompleteClient(sender: RequestCapturingSender(), serializer: MockSerializer())
+        let lookup = USAutocompleteLookup()
+        lookup.source = .postal
+        let request = client.buildRequest(lookup: lookup)
+        XCTAssertEqual(request.parameters["source"], "postal")
+    }
+
+    func testSourceNotInRequestWhenNotSet() {
+        let client = USAutocompleteClient(sender: RequestCapturingSender(), serializer: MockSerializer())
+        let lookup = USAutocompleteLookup()
+        let request = client.buildRequest(lookup: lookup)
+        XCTAssertNil(request.parameters["source"])
     }
 
     func testSendingExclude() {

--- a/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
+++ b/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
@@ -1,0 +1,80 @@
+import XCTest
+import SmartyStreets
+
+class USAutocompleteClientTests: XCTestCase {
+
+    var capturingSender:RequestCapturingSender!
+    var error:NSError!
+
+    override func setUp() {
+        super.setUp()
+        self.capturingSender = RequestCapturingSender()
+        self.error = nil
+    }
+
+    override func tearDown() {
+        super.tearDown()
+        self.capturingSender = nil
+        self.error = nil
+    }
+
+    func testSendingSearchOnlyLookup() {
+        let sender = URLPrefixSender(urlPrefix: "http://localhost", inner: self.capturingSender as Any)
+        let serializer = MockSerializer(result: USAutocompleteResult(dictionary: NSDictionary()))
+        let client = USAutocompleteClient(sender:sender, serializer:serializer)
+        var lookup = USAutocompleteLookup().withSearch(search: "1")
+
+        _ = client.sendLookup(lookup:&lookup, error:&error)
+
+        XCTAssertEqual("1", capturingSender.request.parameters["search"])
+        XCTAssertEqual("city", capturingSender.request.parameters["prefer_geolocation"])
+        XCTAssertNil(self.error)
+    }
+
+    func testSendingFullyPopulatedLookup() {
+        let sender = URLPrefixSender(urlPrefix: "http://localhost", inner: self.capturingSender as Any)
+        let serializer = MockSerializer(result: USAutocompleteResult(dictionary: NSDictionary()))
+        let client = USAutocompleteClient(sender:sender, serializer:serializer)
+        var lookup = USAutocompleteLookup().withSearch(search: "1")
+        lookup.selected = "selectedAddress"
+        lookup.exclude = "excludedAddress"
+        lookup.maxResults = 5
+        lookup.addCityFilter(city: "city")
+        lookup.addStateFilter(state: "state")
+        lookup.excludeStates?.append("excludedState")
+        lookup.addPreferCity(city: "preferCity")
+        lookup.addPreferState(state: "preferState")
+        lookup.preferRatio = 4
+        lookup.source = "all"
+        lookup.addCustomParameter(parameter: "custom", value: "7")
+
+        _ = client.sendLookup(lookup:&lookup, error:&error)
+
+        XCTAssertEqual("1", capturingSender.request.parameters["search"])
+        XCTAssertEqual("selectedAddress", capturingSender.request.parameters["selected"])
+        XCTAssertEqual("excludedAddress", capturingSender.request.parameters["exclude"])
+        XCTAssertEqual("5", capturingSender.request.parameters["max_results"])
+        XCTAssertEqual("city", capturingSender.request.parameters["include_only_cities"])
+        XCTAssertEqual("state", capturingSender.request.parameters["include_only_states"])
+        XCTAssertEqual("excludedState", capturingSender.request.parameters["exclude_states"])
+        XCTAssertEqual("preferCity", capturingSender.request.parameters["prefer_cities"])
+        XCTAssertEqual("preferState", capturingSender.request.parameters["prefer_states"])
+        XCTAssertEqual("4", capturingSender.request.parameters["prefer_ratio"])
+        XCTAssertEqual("all", capturingSender.request.parameters["source"])
+        XCTAssertEqual("7", capturingSender.request.parameters["custom"])
+        XCTAssertNil(self.error)
+    }
+
+    func testSendingExclude() {
+        let sender = URLPrefixSender(urlPrefix: "http://localhost", inner: self.capturingSender as Any)
+        let serializer = MockSerializer(result: USAutocompleteResult(dictionary: NSDictionary()))
+        let client = USAutocompleteClient(sender:sender, serializer:serializer)
+        var lookup = USAutocompleteLookup().withSearch(search: "1")
+        lookup.exclude = "excludedAddress"
+
+        _ = client.sendLookup(lookup:&lookup, error:&error)
+
+        XCTAssertEqual("excludedAddress", capturingSender.request.parameters["exclude"])
+        XCTAssertNil(self.error)
+    }
+}

--- a/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
+++ b/Tests/SmartyStreetsTests/USAutocompleteTests/USAutocompleteClientTests.swift
@@ -37,7 +37,7 @@ class USAutocompleteClientTests: XCTestCase {
         let client = USAutocompleteClient(sender:sender, serializer:serializer)
         var lookup = USAutocompleteLookup().withSearch(search: "1")
         lookup.selected = "selectedAddress"
-        lookup.exclude = "excludedAddress"
+        lookup.addExclude(exclude: "excludedAddress")
         lookup.maxResults = 5
         lookup.addCityFilter(city: "city")
         lookup.addStateFilter(state: "state")
@@ -93,11 +93,11 @@ class USAutocompleteClientTests: XCTestCase {
         let serializer = MockSerializer(result: USAutocompleteResult(dictionary: NSDictionary()))
         let client = USAutocompleteClient(sender:sender, serializer:serializer)
         var lookup = USAutocompleteLookup().withSearch(search: "1")
-        lookup.exclude = "excludedAddress"
+        lookup.exclude = ["excludedAddress", "excludeAddress2"]
 
         _ = client.sendLookup(lookup:&lookup, error:&error)
 
-        XCTAssertEqual("excludedAddress", capturingSender.request.parameters["exclude"])
+        XCTAssertEqual("excludedAddress,excludeAddress2", capturingSender.request.parameters["exclude"])
         XCTAssertNil(self.error)
     }
 }

--- a/samples/Sources/swiftExamples/USAutocompleteExample.swift
+++ b/samples/Sources/swiftExamples/USAutocompleteExample.swift
@@ -59,7 +59,7 @@ class USAutocompleteExample {
         lookup.maxResults = 5
         lookup.preferGeolocation = GeolocateType(name: "none")
         lookup.preferRatio = 33
-        lookup.source = "all"
+        lookup.source = .all
         ///////////////////////////////////////////////////////////////////////////////////////////////
 
         _ = client.sendLookup(lookup: &lookup, error: &error)

--- a/samples/Sources/swiftExamples/USAutocompleteExample.swift
+++ b/samples/Sources/swiftExamples/USAutocompleteExample.swift
@@ -1,0 +1,121 @@
+import Foundation
+import SmartyStreets
+
+// This example is for US Autocomplete (V2). It has the same name as a previous product
+// which has been deprecated since 2022, which we refer to as US Autocomplete Basic.
+// If you are still using US Autocomplete Basic, this SDK will not work.
+class USAutocompleteExample {
+    func run() -> String {
+        //            The appropriate license values to be used for your subscriptions
+        //            can be found on the Subscriptions page of the account dashboard.
+        //            https://www.smartystreets.com/docs/cloud/licensing
+        //            We recommend storing your authentication credentials in environment variables.
+        //            for client-side requests (browser/mobile), use this code:
+        //let id = getEnvironmentVar("SMARTY_AUTH_WEB") ?? ""
+        //let hostname = getEnvironmentVar("SMARTY_AUTH_REFERER") ?? ""
+        //let client = ClientBuilder(id: id, hostname: hostname).buildUSAutocompleteApiClient()
+
+        // for server-to-server requests, use this code:
+        let authId = getEnvironmentVar("SMARTY_AUTH_ID") ?? ""
+        let authToken = getEnvironmentVar("SMARTY_AUTH_TOKEN") ?? ""
+        let client = ClientBuilder.withBasicAuth(authId: authId, authToken: authToken).buildUSAutocompleteApiClient()
+
+        //            Documentation for input fields can be found at:
+        //            https://www.smarty.com/docs/apis/us-autocomplete-v2/reference#http-request-input-fields
+
+        var lookup = USAutocompleteLookup().withSearch(search: "1042 W Center")
+
+        // Uncomment the below line to add a custom parameter to a lookup:
+        //lookup.addCustomParameter(parameter: "parameter", value: "value")
+
+        var error:NSError! = nil
+
+        _ = client.sendLookup(lookup: &lookup, error: &error)
+
+        if let error = error {
+            let output = """
+            Domain: \(error.domain)
+            Error Code: \(error.code)
+            Description:\n\(error.userInfo[NSLocalizedDescriptionKey] as! NSString)
+            """
+            return output
+        }
+
+        var output = "Result:\n"
+
+        if let result = lookup.result, let suggestions = result.suggestions {
+            for suggestion in suggestions {
+                output.append("\(buildAddress(suggestion: suggestion))\n")
+            }
+        }
+
+        output.append("\nResult with filters:\n")
+
+        ////////////////////// Can be sent with or without the following fields //////////////////////
+        lookup.addCityFilter(city: "Denver,Aurora,CO")
+        lookup.addCityFilter(city: "Orem,UT")
+        lookup.addPreferCity(city: "Orem")
+        lookup.addPreferState(state: "UT")
+        lookup.maxResults = 5
+        lookup.preferGeolocation = GeolocateType(name: "none")
+        lookup.preferRatio = 33
+        lookup.source = "all"
+        ///////////////////////////////////////////////////////////////////////////////////////////////
+
+        _ = client.sendLookup(lookup: &lookup, error: &error)
+
+        if let error = error {
+            let output = """
+            Domain: \(error.domain)
+            Error Code: \(error.code)
+            Description:\n\(error.userInfo[NSLocalizedDescriptionKey] as! NSString)
+            """
+            return output
+        }
+
+        var entryId:String? = nil
+        if let result = lookup.result, let suggestions = result.suggestions {
+            for suggestion in suggestions {
+                output.append("\(buildAddress(suggestion: suggestion))\n")
+                if let id = suggestion.entryId, !id.isEmpty {
+                    entryId = id
+                }
+            }
+        }
+
+        // Expand the secondaries of a result that has an entry_id by passing it back as the selected address.
+        if let entryId = entryId {
+            lookup.selected = entryId
+
+            _ = client.sendLookup(lookup: &lookup, error: &error)
+
+            if let error = error {
+                let output = """
+                Domain: \(error.domain)
+                Error Code: \(error.code)
+                Description:\n\(error.userInfo[NSLocalizedDescriptionKey] as! NSString)
+                """
+                return output
+            }
+
+            output.append("\nSecondaries:\n")
+            if let result = lookup.result, let suggestions = result.suggestions {
+                for suggestion in suggestions {
+                    output.append("\(buildAddress(suggestion: suggestion))\n")
+                }
+            }
+        }
+
+        return output
+    }
+
+    func buildAddress(suggestion: USAutocompleteSuggestion) -> String {
+        var whiteSpace = ""
+        if let entries = suggestion.entries {
+            if entries > 1 {
+                whiteSpace.append(" (\(entries) entries)")
+            }
+        }
+        return "\(suggestion.streetLine ?? "") \(suggestion.secondary ?? "") \(whiteSpace) \(suggestion.city ?? ""), \(suggestion.state ?? "") \(suggestion.zipcode ?? "")"
+    }
+}

--- a/samples/Sources/swiftExamples/main.swift
+++ b/samples/Sources/swiftExamples/main.swift
@@ -8,6 +8,7 @@ import Foundation
 // print(USZipCodeSingleLookupExample().run())
 // print(USZipCodeMultipleLookupsExample().run())
 // print(USAutocompleteProExample().run())
+// print(USAutocompleteExample().run())
 // print(USExtractExample().run())
 // print(InternationalStreetExample().run())
 // print(InternationalAutocompleteExample().run())


### PR DESCRIPTION
- New US Autocomplete module: Lookup, Client, Suggestion (+ Result/serializer where applicable)
- ClientBuilder method to build the client
- Unit tests, plus an example demonstrating filtered lookups and secondary
    expansion (capture an entry_id, pass it back as `selected`)